### PR TITLE
添加jsDelivr CDN镜像

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@
 主规则订阅地址
 `https://raw.githubusercontent.com/banbendalao/ADgk/master/ADgk.txt`
 
+主规则jsDelivr CDN镜像
+`https://cdn.jsdelivr.net/gh/banbendalao/ADgk@master/ADgk.txt`
+
 主规则coding镜像
 `https://banbendalao.coding.net/p/adgk/d/ADgk/git/raw/master/ADgk.txt`
 
 百度搜索结果内屏蔽百家号
 `https://raw.githubusercontent.com/banbendalao/ADgk/master/kill-baidu-ad.txt`
+
+百度搜索结果内屏蔽百家号jsDelivr CDN镜像
+`https://cdn.jsdelivr.net/gh/banbendalao/ADgk@master/kill-baidu-ad.txt`
 
 百度搜索结果内屏蔽百家号coding镜像
 `https://banbendalao.coding.net/p/adgk/d/ADgk/git/raw/master/kill-baidu-ad.txt`


### PR DESCRIPTION
jsDelivr CDN，境外目前唯一拿到国内ISP执照的cdn，国内外各大网站加载样式表脚本的首选，速度很快

亦提供repo大小小于50mb的gh镜像服务，比如[atilo](https://github.com/YadominJinta/atilo/blob/master/atilo#L62)，以及[via本身内置的一个规则](https://cdn.jsdelivr.net/gh/o0HalfLife0o/list/ad3.txt)