### PR TITLE
Remove some redundant rules

### DIFF
--- a/ADgk.txt
+++ b/ADgk.txt
@@ -1,4 +1,4 @@
-! Version: 20220208001230
+! Version: 20220223225145
 ! Title: adgk手机去广告规则
 ! Homepage: https://github.com/banbendalao/ADgk
 ! by: 坂本dalao
@@ -50,7 +50,6 @@ m.sm.cn$$div[ad_dot_url="adclick"]
 ||image-ad.sm.cn^
 ||sm.cn/adclick
 ||sm.cn/conn
-||zm.sm-tc.cn^
 ||fourier.taobao.com^
 ||sugs.m.sm.cn^
 ||gayeah.cn^
@@ -417,7 +416,6 @@ csdn.net$$div[class="weixin-shadowbox wap-shadowbox"]
 ||qh.la/static/js/nrwzl.js
 ||xunleiii.com^
 /hm.js^$third-party
-(com?$third-party
 ||errlog.umeng.com^
 ||lfsenmei.com^
 ||hupu-nba.com^
@@ -523,7 +521,6 @@ tieba.baidu.com##.banner-wrapper
 ||www.coolapk.com/feed/$removeparam=shareUid|shareFrom
 ||linglong001.com^
 ||packsss.com^
-||wbapp.mobile.sina.cn/wbapplua/wbpullad.lua
 ||baidu.com/*/webb.gif^
 ||log3-normal-hl.toutiaoapi.com^
 ||jiaruntian.com^
@@ -602,7 +599,6 @@ nfstar.net$$a[href="discountminds.com"]
 ||xlgtblj.cn^
 ||log.m.sm.cn^
 ||log-api.pangolin-sdk-toutiao.com^
-||toblog.ctobsnssdk.com^
 ||newlog.reader.qq.com^
 ||pstatp.com/site/reads-sdk/
 ||log6.reader.qq.com^
@@ -737,7 +733,6 @@ bde4.com,bde4.cc$$script[tag-content="yabo"]
 bde4.com,bde4.cc$$script[tag-content="ads"]
 ||rijutv.com/statics/skin/hjtv-wap/js/plus.js?
 ||rijutv.com/statics/ajs/alltj.js
-||rijutv.com/statics/alljs/rijutvapp.js?
 ||c.mse.360.cn^
 ||se.360.cn^
 ||sdk.look.360.cn/sdkv2/popconf?
@@ -1146,8 +1141,6 @@ www.iqiyi.com/*.html##.rightpcadv,.pca-img
 ||adsystem.wasu.tv
 ||a.v.duowan.com/
 ||m.baidu.com/his?callback=jsonp1&type=3&pic=1&lid=2037637247&ishome=1&net=1&islogin=0&hissid=123406,109775,102628,123925,123093,120142,118882,118864,118846,118833,118794,120549,107320,117332,122788,124072,123573,123813,123956,123809,123853,123699,123980,124030,110085,123289&_=1528306435369
-||m.baidu.com/tc?tcreq4log=1&r=1528306435328&logid=2037637247&from=844b&pu=sz%2540320_1001%252Cta%2540iphone_2_6.0_3_537&ct=10&cst=1&ref=index_iphone&logFrom=index
-||m.baidu.com/tc?tcreq4log=1&r=1528306435685&logid=2037637247&from=844b&pu=sz%2540320_1001%252Cta%2540iphone_2_6.0_3_537&ct=10&cst=1&ref=index_iphone&logInfo=show_baiduapp_ad&logFrom=callbaidu
 ||m.baidu.com/logo.gif
 ||bcfeedback.taobao.com^
 ||img2.user.kanimg.com^
@@ -3621,7 +3614,6 @@ www.yeyou1.com##img[src^="http://www.yeyou1.com/images/"],div.left-box
 www.yiihuu.com##div.popup-ad
 www.you85.cn##div.a_pb,div.a_pt,div.a_mu
 www.you85.com##div.a_pb,div.a_pt,div.a_mu
-www.youdao.com##div#spTop.sp-h
 www.youfuli8.com##div.textwidget
 www.ytbbs.com##div.lt_ad,div.fend_ad,.ad,div.a_pr,div.ftop_ad
 www.yunaw.com##img[src*=".tietuku.com/"],img[src="http://yunaw.qiniudn.com/tuixiao.png"]
@@ -5099,7 +5091,7 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||lhafy.com^
 ||liangao.com$third-party
 ||liangziweixg.com^
-||lianmeng.360.cn$third-party,domain=~xinhuanet.com
+||lianmeng.360.cn^$third-party,domain=~xinhuanet.com
 ||lianmeng.com^
 ||liaocpa.com$third-party
 ||lieqitianxia.cn^
@@ -5176,7 +5168,7 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||mbai.cn$third-party
 ||media.news18a.com/js/$third-party,script
 ||media8.cn^
-||mediav.com^$domain=~v5bjq.com|~999.com
+||mediav.com^$domain=~v5bjq.com|~999.com|dev.360.cn
 ||megpacokjce.bid
 ||meitissp.com^
 ||meiyouad.com/user/union?t=
@@ -6052,7 +6044,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||exceptionlog.kugou.com^
 ||mobilecdngz.kugou.com/new/app^
 ||serveraddr.service.kugou.com^
-||m.baidu.com/tc?tcreq4log=1&r=1530262217331&logid=3016472129&from=844b&pu=sz%25401320_1001%252Cta%2540iphone_2_6.0_3_537&ct=10&cst=1&ref=index_iphone&logFrom=index
 @@||wx3.sinaimg.cn/wap720^
 @@||android.bugly.qq.com/rqd/async?aid=47fefd70-7c99-4821-b989-25e49187e5e2$app=com.bilibili.app.blue
 @@||changyan.sohu.com/api/2^$app=com.biquge.ebook.app
@@ -6072,7 +6063,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 user.qzone.qq.com###site_hot_btn
 qzone.qq.com##div.feed-hot-bar
 qzone.qq.com##div.f-vqz-ad
-cnc.qzs.qq.com###bottom-sponsor
 user.qzone.qq.com###QM_Container_11
 qzone.qq.com###js-qq-ad
 user.qzone.qq.com###QM_Container_100005[/mw_shl_code]
@@ -6231,7 +6221,6 @@ checkadblock.ru##*ad*
 ||img.kingsnug.cn/Public/js/jquery.raty.min.js$domain=nicotv.cc
 ||s8.qhres.com/static/*.js$domain=nicotv.cc
 ||*.legou*.com/images/*.gif$domain=lsj.tt-hk.cn
-||m.legou361.com/dijuh^$domain=lsj.tt-hk.cn
 ||lsj.tt-hk.cn/api.php?url=http:^$domain=lsj.tt-hk.cn
 ||bmp.mm323.com/sdk/lt02.php?reef=https:^$domain=lsj.tt-hk.cn
 ||www.jqaaa.com/jq1/api.php?url=http:^$domain=jqaaa.com
@@ -6367,7 +6356,6 @@ play.baidu.com###m-client-product,#right-ads,div.rightAd-skin,.top-banner-ad-wra
 ||uum6.com/$third-party,~font,popup
 ||um29.com/$third-party,~font,popup
 ||w8.com.cn^
-||wrating.com/$domain=~tudou.com
 ||xcdf.cn^
 ||xmshqh.com/
 ||xiacaidd.com/
@@ -6635,10 +6623,8 @@ tieba.baidu.com##frs-tuijian,tl_gap,p_article,p_hot,p_show,s_post.post_user,p_me
 ||zhiong.net^
 ||cferw.com^
 ||xxguan.cn^
-||lianmeng.360.cn^
 ||ipinyou.com^
 ||mct01.com^
-||wrating.com^
 ||rdtuijian.com^
 push.qq.com^
 wxsnsdy.tc.qq.com^
@@ -6746,7 +6732,6 @@ iadctest.qwapi.com^
 ||madhouse.cn^
 ||madserving.com^
 ||mbai.cn^
-||mediav.com^
 ||mgogo.com^
 ||microad-cn.com^
 ||miidi.net^
@@ -8236,7 +8221,6 @@ _showad*
 ||m.haxdu.com/hi18^
 tieba.baidu.com$$img[class="fixed_bar_"]
 s.parentNode.insertBefore(hm, s);
-||h5.ssp.qq.com/static/web/websites/
 ||vip.catcs.cn^
 ||aishangcan.com^
 ||m.gao7.com/news/GetGameRelationPack.ajax
@@ -8267,7 +8251,6 @@ $domain=m.fengyunok.com,third-party
 ||log-stats.weathercn.com^
 ||em.baidu.com^
 ||adashbc.ut.taobao.com^
-||c.ssp.qq.com^
 p*-dy.bytecdn.cn/large/*.jpeg
 ||renren*.maoyun.tv/apptu/
 ||playcvn.com/app^
@@ -10790,7 +10773,6 @@ _xiuno_com_ad/
 ||lhzly.com^$third-party
 ||liangyi360.com^$third-party
 ||lianle.com^$third-party
-||lianmeng.360.cn^$domain=~lianmeng.360.cn
 ||librarymanagement.cn^
 ||lifu11.com^
 ||linjiajia.cn^
@@ -11807,7 +11789,6 @@ _yad_jsonp_
 ||543et.com/detail/
 ||5442tu.com/style/ads5442.js
 ||54new.com*/da/
-||55.la/anonymous/banner/$domain=lxty66.com
 ||55aaee.com/detail/
 ||55sky.com/js/diecuo/
 ||56ads.com/js/main.js
@@ -12792,11 +12773,6 @@ _yad_jsonp_
 ||delivery.wasu.cn^
 ||demaxiya.com/v4/dd/
 ||deyangs.com/img/
-||dfcfw.com/EMFloatFrame/
-||dfcfw.com/js/*/emfloatmedia_
-||dfcfw.com/js/default/left_
-||dfcfw.com/public/js/left.js
-||dfcfw.com/tg/
 ||dianjinghu.com/static/frontend/images/lol/penpen
 ||dianping.com/mkt/ajax/getNewItems
 ||dianping.com/wedding/pro/jsonppage
@@ -14340,8 +14316,6 @@ _yad_jsonp_
 ||putonghua520.com/skins/10ym/baicai.gif
 ||puudeng.com.tw^$subdocument
 ||pv966.us/js/tw.js
-||pw321.com/bulu/
-||pw321.com^*.gif
 ||pythontab.com/statics/images/*abc
 ||pythontab.com/statics/images/*ads
 ||pythontab.com/statics/images/*comp
@@ -14478,7 +14452,6 @@ _yad_jsonp_
 ||ratedxbiz.com/d/
 ||rayfile.com/media/img/rili_
 ||rdance.cn/g-
-||realsrv.com/popunder1000.js
 ||redshu.com/js/pcAdv.js
 ||redshu.com/js/www/jquerygg.js
 ||rentiyishu.org/*.js
@@ -14615,7 +14588,6 @@ _yad_jsonp_
 ||shouji.com.cn/static/v2/images/sj_banner_
 ||shouyoutv.com/assets/api/web/v4/js/global_head.js
 ||showhaotu.$domain=18board.com|18p2p.com
-||shspdt.com^$domain=11papapa.com
 ||shufazidian.com/float/yanue.
 ||shufazidian.com/image/728x90ty.jpg
 ||shulihua.net/js/gzlishi468google.js
@@ -15158,7 +15130,6 @@ _yad_jsonp_
 ||wzbaohe.com/imgadnew/midad.js
 ||x-resource05.com/media_orange/server-img/*_1200_120.
 ||x3cn.com/data/attachment/portal/*.gif
-||x6img.com^$domain=picturedata.org
 ||x7w7.com/js/float
 ||x81zw.com/hf.js
 ||xc.macd.cn^
@@ -20504,7 +20475,6 @@ gohome.com.hk#@#div[id^="div-gpt-ad"]
 @@||media.org.hk^*/ads_
 @@||mediav.com/js/feed_ts.js$domain=toutiao.china.com
 @@||mediav.com/js/interactive_plugin.js$domain=v.360kan.com
-@@||mediav.com^$domain=dev.360.cn
 @@||meizu.com/fileserver/ad/img/
 @@||miaozhen.com^*/m.suning.
 @@||mm.maxthon.cn/ad/
@@ -21553,7 +21523,6 @@ ifeng.com,~imall.ifeng.com##a[href*="imall.ifeng."]
 ||com/js/ddd.js
 ||com/js/indextop.js
 googleads.g.doubleclick.net###mys-wrapper
-(com?$script,third-party
 /1*.html?|$script,third-party,xmlhttprequest
 /1*.xhtml?|$script,third-party,xmlhttprequest
 /1xhtml?$script,third-party
@@ -22573,7 +22542,6 @@ fqsousou.com,kengso.com#@#.user-share
 ||hjfile.cn/analytics/site/TrackEvent.js
 ||h-adashx.ut.taobao.com^
 ||ug.snssdk.com^
-@@||api.ad-gone.com^
 $image,domain=ip.cn
 ||x.jd.com^
 ||agstat.html5.qq.com^


### PR DESCRIPTION
{www.youdao.com##div#spTop.sp-h} is redundant because {youdao.com###topImgAd,#spTop}
{cnc.qzs.qq.com###bottom-sponsor} is redundant because {qq.com###bottom-sponsor}
{||realsrv.com/popunder1000.js} is redundant because {||realsrv.com^}
{||dfcfw.com/EMFloatFrame/} is redundant because {||dfcfw.com^}
{||dfcfw.com/js/*/emfloatmedia_} is redundant because {||dfcfw.com^}
{||dfcfw.com/js/default/left_} is redundant because {||dfcfw.com^}
{||dfcfw.com/public/js/left.js} is redundant because {||dfcfw.com^}
{||dfcfw.com/tg/} is redundant because {||dfcfw.com^}
{||m.baidu.com/tc?tcreq4log=1&r=1528306435328&logid=2037637247&from=844b&pu=sz%2540320_1001%252Cta%2540iphone_2_6.0_3_537&ct=10&cst=1&ref=index_iphone&logFrom=index} is redundant because {||baidu.com/tc?}
{||m.baidu.com/tc?tcreq4log=1&r=1528306435685&logid=2037637247&from=844b&pu=sz%2540320_1001%252Cta%2540iphone_2_6.0_3_537&ct=10&cst=1&ref=index_iphone&logInfo=show_baiduapp_ad&logFrom=callbaidu} is redundant because {||baidu.com/tc?}
{||m.baidu.com/tc?tcreq4log=1&r=1530262217331&logid=3016472129&from=844b&pu=sz%25401320_1001%252Cta%2540iphone_2_6.0_3_537&ct=10&cst=1&ref=index_iphone&logFrom=index} is redundant because {||baidu.com/tc?}
{||x6img.com^$domain=picturedata.org} is redundant because {||x6img.com^}
{@@||api.ad-gone.com^} is redundant because {@@||ad-gone.com^}
{||wbapp.mobile.sina.cn/wbapplua/wbpullad.lua} is redundant because {||wbapp.mobile.sina.cn^}
{||toblog.ctobsnssdk.com^} is redundant because {||ctobsnssdk.com^}
{||rijutv.com/statics/alljs/rijutvapp.js?} is redundant because {||rijutv.com/statics/alljs^}
{||wrating.com^} is redundant because {||wrating.com^$third-party,domain=~tudou.com|~v.ifeng.com}
{||wrating.com/$domain=~tudou.com} is redundant because {||wrating.com^$third-party,domain=~tudou.com|~v.ifeng.com}
{||m.legou361.com/dijuh^$domain=lsj.tt-hk.cn} is redundant because {||legou361.com^}
{||shspdt.com^$domain=11papapa.com} is redundant because {||shspdt.com^}
{||pw321.com/bulu/} is redundant because {||pw321.com^}
{||pw321.com^*.gif} is redundant because {||pw321.com^}
{||zm.sm-tc.cn^} is redundant because {||sm-tc.cn^}
{||h5.ssp.qq.com/static/web/websites/} is redundant because {||ssp.qq.com^}
{||c.ssp.qq.com^} is redundant because {||ssp.qq.com^}
{||55.la/anonymous/banner/$domain=lxty66.com} is redundant because {||55.la}

{||mediav.com^} {@@||mediav.com^$domain=dev.360.cn} {||mediav.com^$domain=~v5bjq.com|~999.com} > {||mediav.com^$domain=~v5bjq.com|~999.com|~dev.360.cn}
{||lianmeng.360.cn^$domain=~lianmeng.360.cn} {||lianmeng.360.cn^} {||lianmeng.360.cn$third-party,domain=~xinhuanet.com} > {||lianmeng.360.cn^$third-party,domain=~xinhuanet.com}
{(com?$script,third-party} {(com?$third-party} strange so removed