### PR TITLE
Update ADgk.txt

### DIFF
--- a/ADgk.txt
+++ b/ADgk.txt
@@ -1,7 +1,10 @@
-! Version: 20220304000907
+! Version: 20220304121424
 ! Title: adgk手机去广告规则
 ! Homepage: https://github.com/banbendalao/ADgk
+！本规则为开源规则，严禁用于任何商业用途
+！规则反馈群：875865300
 ! by: 坂本dalao
+
 ||kingsoft-office-service.com/ad?
 ||adres.wpscdn.cn^
 ||c.sm.cn^
@@ -286,7 +289,6 @@ csdn.net$$div[class="weixin-shadowbox wap-shadowbox"]
 ||cxojob.com.cn^
 ||7656c4.com^
 ||bzyunding.com^
-||just-machinery.com^
 ||yhdm.so/js/js/51yh.js
 ||xjuneuud.cn^
 ||watbt.top^
@@ -363,7 +365,6 @@ csdn.net$$div[class="weixin-shadowbox wap-shadowbox"]
 pornhub.com$$div[class="bottomNav clearfix"]
 baidu.com##div.FYB_RD
 ||hncsdayu.com^
-||govjiangsu.cn^
 ||image.airav.life/AirADPic^
 ||www.javdove5.xyz/static/resources/images^
 ||adxadserv.com^
@@ -440,7 +441,6 @@ tieba.baidu.com##.banner-wrapper
 ||nuaaad.cn^
 ||mmkkiivv.com^
 ||sunjianlong.com^
-||nggwhyk.cn^
 ||static.cloudflareinsights.com/beacon.min.js
 $third-party,domain=baoshuu.com
 ||yyslate.com^
@@ -466,12 +466,9 @@ nfstar.net$$a[href="discountminds.com"]
 ||661291.com^
 ||longdehua.com^
 ||zzcmjn.com^
-||govhunan.cn^
 ||xiseba.org/js/abc^
 ||toujing*.top^
 ||systemcity.cn/feed.php
-||pinwu123.com^
-||uuboos.com^
 ||zzyanhushi.com^
 ||pangolin-sdk-toutiao-b.com^
 ||gtimg.cn/*_ad^
@@ -539,7 +536,6 @@ bde4.cc##div:last-child > a:last-child > img
 ||huafujr.com^
 ||xuanxuan520.com^
 ||biduo.cc/js/kanwo.js
-||sysycloud.com^
 ||taisi666.top^
 ||kkbiqu2.com/js/yuedu.js
 ||58xwz.cn^
@@ -723,8 +719,6 @@ zhenbuka.com$$a[href="ybvip1879.vip"]
 ||jsjs.jbzj.com^
 $third-party,domain=biquge001.com|shuquge.com|biqu.ge|xbiquge.la|biquw.com|biquge5200.cc|yuanzunxs.cc|biqubao.com|biquge.tv|12zw.com|biqugle.com|32xs.org|biqugeg.com|biqugedu.com|xswang.com|biquduge.com|gebiqu.com|xshengyan.com|bbiqugew.com|biquges.com|xsbiquge.com|ibqg5200.com|biquge.info|biquwu.cc|biquger.com|mybooks8.com|zzbiquge.com|3xs.cc|biquge123.com|yiyi120.com|zuimeng8.com|biquga.com|hehuamei.com|biquku.la|biqug.org|biqugewx.com
 $script,third-party,domain=rijutv.com
-@@||cdn.bootcss.com^$script,domain=rijutv.com
-@@||cdn.staticfile.org^$script,domain=rijutv.com
 $script,third-party,domain=m.1kkk.com|m.dm5.com
 @@||cdndm5.com^$script,domain=m.1kkk.com|m.dm5.com
 $popup,third-party,domain=downdv.com|rmdown.com|soyunpan.com|youtubeto.com
@@ -890,7 +884,6 @@ linuxbaike.com$$div[class="fadacai"]
 ||js2.hdzog.com^
 ||trafficforce.com^
 ||tsyndicate.com^
-||riverhit.com^
 ||trafforsrv.com^
 ||a.dtprofit.com^
 ||tieba.baidu.com/mo/q/checkurl?url=
@@ -2537,7 +2530,6 @@ qianjia.com##.ad-section
 qiannao.com##A[href="http://www.2tietu.com/"],div#rightDiv,div[style="padding-left:20px;margin-top:10px;"],div#tg2_main,img[src^="http://i1.imgbus.com/doimg/"],ins.adsbygoogle,div#yzjy_div
 qianyan001.com##div.gg,div.gg2,div[class*="_gg"]
 qianyifa.net###ad_text
-qianzhan.com##DIV[id^="baidu_ad_"]
 qianzhan.com##[src^="http://img3.qianzhan123.com/gg/"]
 qicheyinyue.wang##[style="height:280px;width:280px;"]
 qidian.com###page-ops
@@ -2665,7 +2657,7 @@ shangxueba.com##[style="position:relative;"],[class^="banner300_250"]
 shanhe.cc##.ad
 shaoxing.com.cn##[src^="6201.files/gg"],[height="50"]
 share.popgo.org##div#bottom_ads
-shenchuang.com###all,.ad,[class^="MainR_ad"],#PcPoPmarket
+shenchuang.com##.ad,[class^="MainR_ad"],#PcPoPmarket
 shhhy.org###frameMLzskg
 shhhy.xyz###diy1.area
 shinybbs.info##.a_h,.a_mu
@@ -2742,7 +2734,7 @@ startos.com##div.test-240
 steachs.com##.adsense,[id^="div-gpt-ad-"],.adsbygoogle
 steamcn.com##.qingyyu_f,[class^="stcn_a_"],.stcn_a_hh,.stcn_a_f,.gou_li_guo_jia_mu,.gou_li_guo_jia_h,.gou_li_guo_jia_f,.gou_li_guo_jia_pr,[class^="qy821_ai_"],.qy821_ai_h,[class$="_ai_f"],[class$="_ai_h"],[class$="_ai_pr"]
 stheadline.com##[class^="ad_"]
-stnn.cc###FloatDIV,.full-banner,.basehr + div[style],#xingdaohuanqiuwang_640_90_a,#xingdaohuanqiuwang_640_90_a + * + * + DIV[style],#xingdaohuanqiuwang_300_250_a
+stnn.cc##.full-banner,.basehr + div[style],#xingdaohuanqiuwang_640_90_a,#xingdaohuanqiuwang_640_90_a + * + * + DIV[style],#xingdaohuanqiuwang_300_250_a
 stock.qq.com##.ad,.phone_ad_1000
 stoneip.info##[id^="aswift_"],.adsbygoogle,[class^="advertising"]
 storebt.cc##[href^="http://go.gotourl"]
@@ -3504,7 +3496,6 @@ zimuku.cn##[style*="width:100%; height:80px;"]
 zimuku.net,zimuku.cn###xianliaome_window,[height="90px"],[height="80px"],[style^="width:820px;height:90px;"],ins.adsbygoogle,div.ad
 zimushe.com##[href^="https://www.zimushe.com/go.php?url=http"],.videobg
 zimuzu.tv###bbs_list_ad,ul.room,div.lx167,A[href^="http://www.rrliuxue.com"],div.rrmj_ad,div.ad,div[class="couplet couplet_l"],a[href^="http://www.jianai360.com"],#help,#xianliaome_window
-ziyouge.com###toadsend
 ziyuanbu.cn##[class^="ad"],#advert-7
 zjjzx.cn##img[src^="http://www.zjjzx.cn/img/zt/yd/"],[id^="Rightgg_banner_"]
 zjol.com.cn##.h50,.h100,[class="mt10"],[class^="a-d-"],#ad1_1,#ad1_2,.wp.a_t,[class="row mb20 cf"],#globalbanner,.banner,.bannnerSadv,.lBottomAD,.lTopAD,[width="1000"][height="65"],[width="520"][height="74"]
@@ -3572,7 +3563,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||11qqmm.com/java/$script
 ||12291.com^
 ||12306media.com^
-||12365chia.com^
 ||123du.cc/show/2/
 ||123lm.com$third-party
 ||123ppk.com^
@@ -3690,7 +3680,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||3munion.net^
 ||3p-link.com^
 ||3shangyou.com^
-||3ygww.com^
 ||43423.com/template/skin1/images/g_js/
 ||4399.com/js/rice/m.js
 ||4466.com/4466/
@@ -3787,7 +3776,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||84232.com^
 ||84pb.com/go.js
 ||84pb.com/pv.js
-||8521448.com^
 ||85un.com^
 ||86fm.com^
 ||8794.cn/js/mx
@@ -3838,7 +3826,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||a7shun.com^
 ||aa.sdo.com^
 ||ab44.pw
-||acasys88.cn^
 ||ad1.greedland.net^
 ||ad8.cc^
 ||adash.m.taobao.com^
@@ -3947,7 +3934,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||bbuni.com^
 ||bdstaic.com/r/www/cache/static/plugins/every_cookie_*.js
 ||bdstatic.com/*/static/indexher/container/module/gameyixing/$script
-||bdtongfei.cn^
 ||behe.com^
 ||beibeigoudai.com^
 ||beigedi.com^
@@ -3959,7 +3945,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||biddingx.com^
 ||bigdramas.net/wp-content/themes/videotube/common.min.js
 ||biqqc.com/ps/data.js
-||biqqc.com/templates/frontend/frontend-default/js/scoll_bg.js
 ||biz37.net^
 ||biz5.sandai.net^
 ||bizhiku.net^
@@ -3968,7 +3953,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||blkxszh.com/zj/
 ||blogad.com.tw$third-party
 ||bloggerads.net$third-party
-||bmgan.com^
 ||bmw100.cn^
 ||bnet.com^
 ||bnuni.com^
@@ -3997,7 +3981,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||buzzads.com^
 ||bx0635.com/tx/$image
 ||bxg68.com^
-||bxgmb.com^
 ||bxwx8.org/wap/qijixs/afoot.js
 ||by.tel.cdndm.com^
 ||ca.bxwx3.org
@@ -4016,7 +3999,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||cdn.zampdsp.com/static/scripts/
 ||cdnads.com^
 ||cdnjsp.wang
-||cg2017.com^
 ||chanet.com.cn$third-party
 ||chatango.com/js/gz/emb.js
 ||cheer.cjoy.com.cn^
@@ -4156,7 +4138,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||dytt8.net/js$script
 ||dzz8.com/public/ptcms/s_wap_novelsearch_chapter_read.js
 ||e399.com^
-||e70123.com^
 ||e719.net$domain=~www.flv.tv
 ||ec.yimg.com^
 ||edu.51cto.com/js/edu-ad.js
@@ -4196,7 +4177,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||flzyw.com/js/foot.js
 ||fmgoal.com^
 ||focuscat.com^
-||focusprolight.com^
 ||food5.net$third-party
 ||fotao9.com$script
 ||founseezb.cn^
@@ -4255,7 +4235,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||gs307.com^
 ||gt1n.com^
 ||gus.host
-||gydag.com^
 ||gygdmy.com^
 ||gyrtg.com^
 ||gythsg.com^
@@ -4284,7 +4263,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||heima8.com^
 ||henghost.com/data/forum-$script
 ||heroclick.cn^
-||hesxz.com^
 ||heygugu.com$script
 ||hfrxs.com/js/hf$script
 ||hgyouxi.net/data/hgyouxiad/attach
@@ -4540,7 +4518,7 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||mbai.cn$third-party
 ||media.news18a.com/js/$third-party,script
 ||media8.cn^
-||mediav.com^$domain=~v5bjq.com|~999.com|dev.360.cn
+||mediav.com^$domain=~v5bjq.com|~999.com|~dev.360.cn
 ||megpacokjce.bid
 ||meitissp.com^
 ||meiyouad.com/user/union?t=
@@ -4662,7 +4640,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||ppoi.org
 ||ppsimg.com/apd/img/
 ||ppunion.com^
-||pr00001.com^
 ||projectpoi.com^
 ||propellerads.com^
 ||prscripts.com/pub
@@ -4678,7 +4655,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||qd.snwx.com^
 ||qdcode.com^
 ||qdimg.com/css/baidu.js|
-||qhaif.com^
 ||qhdjhw.com^
 ||qidian.com/ejs/qd/js/read.qidian.com/bgOps
 ||qidian.com/javascript/SNDAADAltern.js$script
@@ -4725,7 +4701,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||res.qhupdate.com^
 ||resource.tompda.com/static/img/$object
 ||rexuebi.com^
-||rh.qq.com^
 ||runtujs.com^
 ||rwjfs.com$domain=~2mm.tv|~2mmei.com
 ||rxdsj.com/Runtime/js/vod
@@ -4816,7 +4791,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||sysad.cn^
 ||szhyzkj.com^
 ||szltwl.com^
-||szrk3.com^
 ||t.58xs.com/hot/
 ||t157.com^
 ||t3nlink.com^
@@ -4958,7 +4932,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||whcrdz.com^
 ||whdafei.com^
 ||whoclick.cn^
-||whpxy.com^
 ||wjgglm.com$third-party
 ||wkdown.info/bmw*.gif$image
 ||wkdown.info/bt.php?
@@ -5089,7 +5062,6 @@ zznews.cn##.ad:not([style="margin-top:0px;padding-top:0px;"]),.ad1000-60
 ||yidu.cn^
 ||yieldmanager.com^
 ||yigao.com^
-||yigyx.com^
 ||yiiwoo.com^
 ||yiiyoo.net^
 ||yinoo.cn^
@@ -5696,9 +5668,6 @@ m.bilibili.com##DIV.index__container__src-commonComponent-bottomOpenApp-
 ||ading.
 ||audid-api.taobao.com/v2.0/a^$third-party
 ||um*.com^$third-party
-！本规则为开源规则，严禁用于任何商业用途
-！开源项目地址：https://m.gitee.com/banbendalao/adguard
-！规则反馈群：875865300
 ||kzsha.com^
 ||coco988.cn^
 ||58.218.215.145^
@@ -6514,7 +6483,6 @@ _good_id=
 /bg.swf
 *ads.json?jsoncallback=
 /*AdapterNew.
-&adr=
 /context_static_
 /union.js*
 /qqms_
@@ -6690,7 +6658,6 @@ _ad&callback=
 ||bilibili.com/cm/api/*/pc
 ||bilibili.com/x/report/
 ||uogo.net/uogoplus/
-/*.html?uid=
 -250.js*
 /300250/*
 /61.174.50.
@@ -6909,7 +6876,6 @@ _showad*
 ||crashlytics.com^
 ||yazhouyu.
 ||djjca.
-||fecjf.cn^
 ||019103.com^
 ||1000su.com^
 ||100rifu.com^
@@ -7941,7 +7907,6 @@ bing.com###BottomAppPro
 ||fds.api.xiaomi.com/plato-banner^
 ||commdata.v.qq.com^
 ||amdc.m.taobao.com^
-/3ef|
 ||71.am^
 ||googlevideoads.com^
 ||zgzxs.weathercn.com^
@@ -8111,8 +8076,6 @@ cnbeta.com$$span[class="fr"]
 /hotphone.myzaker.com/refresh_ad.php
 /adpub^
 ||boxer.baidu.com^
-||safe524.xyz^
-||qsmdeyz.cn^
 ||cqzspt888.cn^
 ||adeng.hpplay.cn^
 ||conf.hpplay.cn^
@@ -8282,12 +8245,7 @@ baidu.com$$section[class="hint-fold-results-wrapper hint-no-fold"]
 /Appapi/adlist.php
 /avbebe/ad/*
 /common/cf/*$image,object,domain=~bingfeng.tw
-/cpv/i.php?z=
 /dyxia/js/ny
-/fffddd4345/images/1.js
-/fffddd4345/images/2.js
-/fffddd4345/images/3.js
-/g3/960x90-
 /gg4.
 /gg5.
 /gg6.
@@ -8295,38 +8253,26 @@ baidu.com$$section[class="hint-fold-results-wrapper hint-no-fold"]
 /jianshen8/images/information.jpg
 /jkbd-app/resources/images/a123/maiche
 /keke_winad/template/*layerModel.
-/lenovo/pc/all.js
 /lolmp4-ggdz/*
 /m_dilidili_main.js
 /n6b7/*.js
 /router-firmware-update/dl/js/jr5/up.js
 /sitejs/clys.js
-/sogouAD.
 /stui_ads/*
 /template/default_pc/bbs/daohangxia.
 /wy96ad/*
-/xyz567f/*
 :1314/jiucao/
-###ad08
 ###doyoo_mon_mask
 ###doyoo_monitor
 ~hkcsl.com###gg1
-###new_pop_ad
 ###photo-header-title-content-text-dallor
-##.ad-left-top
 ##.ad_top_close + .bd
 ##.customSlideshow-ad-below
 ##.mylist > a[target="_bank"] > img[src*=".alicdn.com/"]
 ##.mylist > a[target="_bank"] > img[src*="kanjiantu."]
-##a[href*=".17yyba.com/"]
 ##a[href*=".726188.com"]
 ##a[href*=".acuxrecv.cn"]
-##a[href*=".biwbmsyt.cn"]
-##a[href*=".com/?p="][target="_blank"] > img[src$=".gif"]
 ##a[href*=".qpzqxz.com/"]
-##a[href*=".tduou.com/"]
-##a[href*=".tudown.com/"]
-##a[href*="/du505.com"]
 ##a[href^="http://172.247.157.176/"]
 ||cn/?ss=$script,third-party
 ||cn/show?id=$script,third-party
@@ -8351,95 +8297,60 @@ baidu.com$$section[class="hint-fold-results-wrapper hint-no-fold"]
 ||net/vs.php?id=$script,third-party
 ||vip/vs.php?id=$script,third-party
 ||xyz/vs.php?id=$script,third-party
-/i.php?z=$script,third-party
-/k.com?g=$third-party
-/o.php?u=*|*$script,third-party
-/v.php?z=$script,third-party
-|https://4o.cc^
+||4o.cc^
 ||0082tv.net^$third-party
 ||00880808.com^
-||0728w.cn^
-||0937jyg.com^
 ||0bc.top^
 ||0xiaoshuo.com^$third-party
 ||17zhaole.com^$third-party
 ||258pcf.com^
 ||333dm.com^
-||365che.cc^
 ||4ggww.com^
 ||517pass.com^
-||51fuliwang.cn^
 ||6612151.cn^
 ||6612152.cn^
-||6666lm.com^
 ||6avz.com^
 ||6ped2nd3yp.com^
 ||700ok.net^
 ||857yx.com^$third-party
-||8ucdn.com^
 ||9639927.com^$third-party
 ||9868.online^
 ||991pao.com^
-||9kff.com^
-||9w39.com^$third-party
-||adacgov.cn^
 ||admartzone.com^$third-party
-||affiliate.rakuten.co.jp^$third-party
 ||ahhuazhen.com^
 ||allxin.com^
 ||anzhuocpm.com^
 ||awkjs.com^
 ||bazhigu.com^
 ||beijinglvyou.net.cn^
-||bejzz.top^
 ||bivitr.com^
 ||bp776.com^
 ||bttyue.com^$subdocument
-||cadsips.com^
-||chaxinyong.net^
 ||chuhanweb.com^
-||ci-web.cn^
 ||clcassd.com^
 ||coostack.com^$third-party
 ||crazymike.tw^$third-party
-||csgtfruit.com^
-||ct1985.com^
-||dafapai.com^
 ||danangmo.cn^
 ||datafastguru.info^
 ||detuns.com^
 ||dkqapp.cn^
 ||dotmore.com.tw^$third-party,domain=~savebar.com.tw
-||dtrcw.cc^
 ||eddjf.com^
-||einsuran.com.cn^
 ||erosyndc.com^
-||fastable.com^
 ||findqc.com^$third-party
-||fjbzjc.com^
-||ge95.com^
 ||genieesspv.jp^$third-party
 ||gohappy.com.tw^$third-party
 ||gzbywl.com^$third-party
 ||haoyiwang.net^$third-party
-||harridan.cc^
-||hbyingchang.cn^
-||hfsteel.net^
-||hhhhbf.com^
 ||hk662.com^
 ||hmp33.com^
 ||hxscba.com^
-||hz3137.com^$third-party
 ||hzxma.com^
-||iewad.net^
 ||iguang.tw^$third-party
 ||ihualun.com^
-||itemccmod.com^
 ||iuuff.com^
-||iyoowi.com^
 ||jdlcg.cn^
 ||jermr.com^
-||jiasdart.cn^
 ||jlssbz.com^
 ||josipr.com^
 ||jsyxfdj.com^
@@ -8447,9 +8358,7 @@ baidu.com$$section[class="hint-fold-results-wrapper hint-no-fold"]
 ||jxwlkssb.com^
 ||k12shequ.com^
 ||kawinhome.com^
-||ladsblue.com^
 ||lamwatch.com^
-||laolinow.com^
 ||last2.cn^$third-party
 ||librarymanagement.cn^
 ||ltdnc.com^
@@ -8457,58 +8366,32 @@ baidu.com$$section[class="hint-fold-results-wrapper hint-no-fold"]
 ||lyraik.cn^
 ||meicubao.cn^
 ||newjulads.com^
-||newsatads.com^
 ||nijiua.com^
 ||nunc-china.com^
 ||oaer9.cn^
-||orchidscape.net^
 ||ptdrw.com^
-||ptkhy.com^
-||pubbirdf.com^
-||qianfuyin.com^
 ||qingqu.la^
 ||qsj65.com^
-||qtch888.com^
-||qunale888.com/maizhan/
 ||qzmhnk.com^
-||rgdhct.cn^
 ||rjk1.com^
-||rx616.cn^
 ||seaxm.com^$third-party
 ||sgftrrs.com^
 ||shillivee.pro^
-||spectram.pro^
 ||st123.info^
-||swzhaohuo.com.cn^
-||sxbhzs.net^
-||taobaojx.com^
 ||thli43.cn^
 ||txkjad.com^$third-party
-||umjsik.com^
 ||urhu.cn^
 ||urlad.com.tw^$third-party
 ||uvsea.cn^
 ||v707070.com^
-||w3989.com^
-||wuhufengze.com.cn^
-||wuwho.cn^
-||xi0021.com^
 ||xingyao.doubiy.com^
 ||xjidian.com^
-||xunlaile.com^
-||yaoxiaoli.com^
 ||yaoyl.com^
 ||yezijizhang.com^
 ||yk0712.com^
-||ysnj74ed.com^
-||yujiangchu.com^
-||yuyanbaojie.cn^
-||zhongjiangguoji.org^
 ||zry8181.com^
-||zsjyc.top^
 ||zx573.cn^
 ||zyrfanli.com^
-||zzwflxs.com^
 ||189.gd^*.html?p=$popup,third-party
 ||com/?Intr=$popup,third-party
 |https:$popup,third-party,domain=88files.net|99files.net|avsdown.com|downdvs.com|jandown.com
@@ -8563,7 +8446,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||127.net/m/*/promPic.jpg
 ||159i.com/nd/b_slest.php
 ||159i.com/p/*.js
-||15yc.cc/statics/js/ffffff.js
 ||17ce.com/k
 ||17ce.com/p
 ||17ce.com/t
@@ -8580,36 +8462,24 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||24mn.me/js/total.js
 ||25bmm.com/js
 ||31bmm.com:8888/js
-||333tv.com/wp-content/themes/Loostrive/cssg/
 ||33405.com/js/layer.js
 ||33405.com/ps/
 ||33405.com/xxxxx.js
 ||33405.com^$subdocument
 ||33av.net/Uploads/ad/
-||33lc.com/bui/
 ||360-bo.com/js/float
-||360buyimg.com^$domain=qianggou5.com
-||38qiqi.com/js/*.aspx
-||38qiqi.com/js/asp/
 ||3bt.cc/xdy_
 ||47ks.com^*_ad.js
 ||4gamers.com.tw/site/api/aols/media?
-||5118.com/8/g.aspx
 ||51dns.tv/pc-
 ||520cc.cc/300aaa.gif
-||520yyqq.com/img/upload/wx.png
 ||5278.cc/index.js
 ||5278bbs.com/adpost_
 ||52pk.com/style/files/images/beitou.jpg
-||52xkyy.com/gcontent/
 ||5dm.tv/html/5dma.jpg
 ||5dm.tv/html/5dmm.jpg
-||5iwanyouxi.com/Runtime/Js/
-||6080.tv/public/js/m/3
-||6080.tv/public/js/m/fa.js
 ||61.235.249.195^*/Default.aspx?id=
 ||64.120.16.146/hsk_update/upload/*.gif
-||66122.com/statics/js/yd.js
 ||66kkl.com/tools/
 ||67.159.44.187/js/v1.js
 ||69.28.57.245^
@@ -8624,29 +8494,24 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||7xsf4r.com1.z0.glb.clouddn.com/lianzi.mp4
 ||86uk.com^$subdocument
 ||880fg.com/css/*.js
-||91dict.com/dub_banner.jpg
 ||91porri.org/fans/
 ||97aa1.com/g/
 ||999sdh.com/tu/*.js
 ||999v.me/cs
 ||99btgc01.info/uploads/*.gif
-||99danji.com/otherhtml/
 ||99jjk.com/js/floatxvideo.js
-||9kjj.com/images/*.gif
 ||a.jiaodong.net/a/2013/
 ||a3v4.top/Picture/aiai.gif
 ||acgsou.com/js/nu
 ||adultblogtoplist.com^$domain=520cc.me
 ||advideoadmin.appledaily.com.tw/ov_player/
 ||ahd.ruten.com.tw^
-||aistat.cn/huodong/
 ||ak47fuli.net/fd.js
 ||ak47fuli.net/wp-content/uploads/20*.gif
 ||alicdn.com^$domain=1024li.com|11papapa.com|1avlang.com|2334n.com|51dll.com|52kpop.com|5xx44.com|5xx77.com|63ef.com|69t41.com|7mav2.com|99a21.com|acglover.me|aotu101.com|camelliadali.com|ccxx99.com|haicao32.com|jb51.net|jitapu.com|junying.com|lady3.xyz|lookpian.com|ppx116.com|qqtenglong.com|qyl00.com|qyl222.com|runoob.com|sodu.cc|spqi.xyz|supfree.net|thztv.cc|tv4.cc|viidii.info|wenkuxiazai.com|xingzhiyin44.com|yeyemo6.com|yuese46.com|yzz12.com|zhuankezhijia.com
 ||aliyuncs.com/pool/20180829220557.png
 ||aliyuncs.com/pool/20180829221932.png
 ||alxx520.com/ad/
-||am.zhiding.cn/www/images/$image,object,subdocument
 ||aoshi.com/jpfans.jpg
 ||aoshi.com/jpseek.jpg
 ||aqy102.com/js/aqy/
@@ -8693,15 +8558,9 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||chinataxservice.cn/static/jquery.1.1.4.min.jxh.js
 ||chinaz.com/2020/0211/2020021115354424.jpg
 ||chumanzi.com/wap
-||ck101.com/api.php?mod=ad&
-||ck101.com/api.php?mod=shopping
-||ck101.com/api.php?mod=taobao&
-||ckcdn.com/c/html5_ad/
 ||cmdy5.com/js/300.js
 ||cmdy5.com/js/waptbplay
 ||cms.fx678img.com^
-||cnzol.com/d/file/p/2019/07/6ac50c702cf9e6a9a7910a510c40cb73.jpg
-||cnzol.com/template/style/images/lcdl.js
 ||cocoawu.b0.upaiyun.com^
 ||codezp.org/uploads/
 ||count.ddooo.com^
@@ -8711,7 +8570,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||cww.net.cn/js/adspaces.js
 ||cy1234.space^*sifang/
 ||dadi.tv/xdy
-||dashenxiaoshuo.com/xiaodingdong/
 ||daybox.net^$domain=12580sky.com
 ||dburl.xyz/js/
 ||dd3200.com/js/favshare.js
@@ -8725,17 +8583,14 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||dpp2019.com/js/swf/
 ||dyncdn.me/static/20/js/expla
 ||dyncdn2.com/static/20/js/expla
-||dytt8.net/js1/
 ||edayday.com/img/ad
 ||etfunhome.com/images/kk.gif
 ||faiusr.com/2/ABUIABACGAAg_dCW0gUo7NqNJjDgATh3.jpg
 ||faiusr.com/3/ABUIABADGAAgkIXb6gUo-L_AwwcwsAk4Wg.gif
 ||fanhaobao.net/wp-content/themes/xiu/js/single.js
-||fashangji.com/gunews/*.js
 ||fcai.com/ifengIndex.html
 ||feixiang211.com/tg/
 ||ffsky.net^$domain=moe-acg.cc
-||file.cloud.sogou.com/*/superzone/
 ||firefoxchina.cn/res/js/fchina_video-min.js
 ||fuimg.com^$domain=678cn.com
 ||fuli69.com/wp-content/uploads/sug
@@ -8743,7 +8598,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||fx110.com/Pub/Ghz/GetModel
 ||fx110.com/Scripts/1.0.0/gulpmin/Ghz/
 ||fx110.com/Styles/1.0.0/dist/Ghz/MatrixAds.
-||g.ousns.net^
 ||gaoqing.la/wp-content/uploads/*/GOOVIS.gif
 ||google.com.hk^$domain=p4vip.com
 ||gum.xbooks.to/js/pc/pc_*_
@@ -8754,12 +8608,8 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||hcomic.in/wp-content/themes/boomog/js/list
 ||heikexs.com/wp-content/themes/Duoxs*/js/
 ||hellojava.com//bja/tanzhou.jpg
-||hxsxw.com/hxsxw666/
-||i-gamer.net^$domain=cartomad.com|cartonmad.com|cartoomad.com|cartoonad.com|cartoonmad.com
 ||iab03.com/zzz/
 ||iball1990.com:897/js/commerical
-||ibkda.com/other/
-||ibkda.com/some/plusshow.js
 ||idaima.com/ycz/ajax/get_items_for_bejson/
 ||ieche.com/global/*/ad/
 ||ieche.com/InAds/
@@ -8814,7 +8664,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||imgur.com^$domain=560996.com|9dog.pw|histock.tw|moe-acg.cc|wgun.net
 ||ionemanhua.com/js/ad/
 ||ionemanhua.com/js/xvideo.js
-||ip.cn^$csp=style-src 'self' https:
 ||iqtfy.com/upload/vod/620.gif
 ||it168.com/factory/ad/
 ||it168.com/forum/201412/19/151606lvf3btnnotc62rl6.jpg
@@ -8845,7 +8694,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||jinbaozy.com/images/zhangshang.jpg
 ||jipinzw.com^*.php?aid=
 ||jisuxz.com/170320/kaola58058.gif
-||jj20.com/static/js/a.js
 ||jj59.com/sy/banner.js
 ||jjckb.cn/flash/1031ad/
 ||jjr123.com/javascript/dl.js
@@ -8854,9 +8702,7 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||jrjimg.cn/focus/newrenNb.png
 ||jrjimg.cn/zqt-red-1000/js/v3/itg-widget.
 ||js.shiwt.com/110.js
-||jstucdn.com/g3/
 ||jsxf.org/images/
-||juejin.im/v3/web/wbbr/
 ||jwcsb.com.cn/js/neirong.js
 ||jxcn.cn/assets/js/dspshow.js
 ||jxgdw.com/images/jdgg.jpg
@@ -8866,7 +8712,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||jz5u.com/new/
 ||kan300.com/js/union/
 ||kanguba.com/file/js/ifr.asp
-||kanjuba.me/js/bbk/
 ||kiwsy.co/hotsearch_box.php
 ||koot.monster/assets/js/ueads.js
 ||kuaidiwo.cn/kuaidiwo.jpg
@@ -8884,11 +8729,8 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||lady8844.com/IMAGE/$~image
 ||lanseshuba.com/react.js
 ||ld12.com/js/myfiles/
-||leagueofmovie.com^*Ads
 ||leiphone.com/uploads/new/article/880_880/201807/5b5687fef17a5.jpg
 ||letvimg.com^*_phone/
-||lewxs.com/file/script/
-||lewxs.com/m-
 ||liangchan.net/aaddaadd/
 ||liangchan.net/adf/
 ||lianmeng.la/klm/
@@ -8897,7 +8739,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||loldyttw.net/blr.js
 ||loldyttw.net/skin/lol/js/ds.js
 ||loli.net/2018/06/12/5b1eb40282e3a.jpg
-||loli.net/2018/09/01/5b8ab2b61cec4.jpg
 ||loli.net/2020/01/20/jenML2kJsAxl6CE.jpg
 ||loli.net^$domain=520film.net|52pili.com|acglover.me|hdsky.me|youtaoqi.com
 ||longbahao.com/asd.js
@@ -8913,9 +8754,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||m3hf.com/js/float
 ||macfans.org/201*.gif
 ||macfans.org/images/*/980x
-||maoyun.tv/fsq/fangshaqi
-||maoyun.tv/g3/
-||maoyun.tv/jk/
 ||mascwgs.com/img/
 ||mbalib.com/wiki/common/wikibits.js
 ||mcchou.com/wp-content/themes/begin/js/mcchou.js
@@ -8925,7 +8763,8 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||meijutt.com/xieziAD.jpg
 ||meipuw.com/style/ad
 ||mikanani.me/images/upupoo
-||mipcdn.com/i/s/https://i.loli.net/$domain=hcomic.in
+||mipcdn.com/i/s/
+||i.loli.net^$domain=hcomic.in
 ||mir300.com/88a/
 ||moe-acg.cc/images/*/1225
 ||moe-acg.cc/images/*/2000x710
@@ -8945,9 +8784,7 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||mt30.com/ok/
 ||myad.toocle.com^
 ||mydrivers.com/2018/drivers/yjgg
-||mydrivers.com/news/2018/wangluodianshi.gif
 ||myjianzhu.com/file/upload/201806/12/192806811.gif
-||myyan.org/js/qz.js
 ||nanren400.com/goto/
 ||naquan.com/packages/assets/js/jquery.reveal.js
 ||narutom.com/v2/js/ca.js
@@ -8979,7 +8816,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||orsoon.com/assets/images/tuidc.png
 ||orzx.im/images/downloader.jpg
 ||ouo.us/nyad/
-||oxxvideos.xyz/static/tmp/
 ||p4vip.com/f*.js
 ||p4vip.com/z*.js
 ||p4vip.com^*.html$subdocument
@@ -8998,8 +8834,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||photofans.cn*/banner/
 ||pianba.tv/api/new_
 ||piaodown.com/other/*.js
-||picuphost.com/2016/upload/image/20170422/42206436302.gif
-||picuphost.com/imghost/upload/image/20171226/122600098149.gif
 ||pigol.cn/myinc/
 ||potplayer.org/sc/
 ||ps110.ru/js/*.js
@@ -9019,7 +8853,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||qhf168.com/data/attachment/portal/
 ||qhimg.com^$domain=1024li.com|mir300.com
 ||qhmsg.com^$domain=1024li.com
-||qiaini.com/js/1mimi.js
 ||qianjia.com/HotImages/2017/11/img20171109122716999.jpg
 ||qihoo.com/hot/text.html?site=
 ||qingchunji.cn/960x
@@ -9050,9 +8883,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||rm66.me/ri.js
 ||rm66.me/tpl/js/i.js
 ||rm66.me/tpl/js/t.js
-||rsdown.cn/static/new0613/down.js
-||rsdown.cn/static/t/
-||ruanyifeng.com/blog/checker.js
 ||rugncn.ifeng.com^
 ||ruiwen.com/js/a/p.js
 ||runsky.com/bbsadv-
@@ -9064,7 +8894,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||scol.com.cn/scol-3/js/08scol_text_
 ||sd888.org/house/flash/
 ||sd888.org/images/tbuyer200.jpg
-||sdgundam.cn/js/91.js
 ||secretmine.net/wp-content/uploads/2019/08/secretmine_20190809_1565312910.jpg
 ||sex2077.com/js/dl.js
 ||sex2077.com/js/gg.js
@@ -9075,39 +8904,26 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||shhgg.in/shlf1314/
 ||shicimingju.com/scmjddd/
 ||shiyanlou.com/img/shiyanlou-
-||shoudian.org/diantong/laoma
 ||shouji.com.cn/static/v2/images/sj_banner_
 ||shufazidian.com/float/yanue.
 ||shufazidian.com/image/728x90ty.jpg
 ||shuqi6.com/static/jquery/gg.js
 ||simplecd.*/static/js/default.js
 ||sinaimg.cn/large/$domain=360-bo.com|chakd.com|seehd.so|xclient.info
-||sinaimg.cn/large/006CZIQPgy1fbzjg10emag30ka02in2s.gif
-||sinaimg.cn/large/006ZdrOOgy1flbruaukyxg30l401o444.gif
-||sinaimg.cn/large/007hXlMJgy1fuyt7uoe5lg30l401o444.gif
-||sinaimg.cn/mw690/005th0Pegy1fmd666rsh2j30go05kn14.jpg
 ||sinaimg.cn/mw690/0060lm7Tly1fwa4j35tfpj30fr0nodg9.jpg
 ||sinaimg.cn/mw690/a1916e89gw1dye4d6qvyaj.jpg
 ||sinaimg.cn/mw690/a1916e89gw1dye4d74zmij.jpg
 ||sj33.cn/js/side.js
 ||sj33.cn/js/tuchong.js
-||sjzdaily.com.cn/sjznewsad/
 ||snbnhngl.ifeng.com^
 ||sodu.cc/js/xufu.js
 ||soft6.com/index.php?m=poster&
-||softhy.net/hp/
-||sogou-inc.com/AdvPreview.
-||sogou.*/js7/forAppDown.js
-||sogou.com/acquireAdvertise.
-||sogou.com/adlist?
-||sogoucdn.com/imgu/*.swf
 ||sogoucdn.com/wap/js/
 ||sogoucdn.com/wapsearch/static/js/videoAppro.
 ||sohucs.com^$domain=renrenfabu.com
 ||sootoo.com/son_media/msg/2010/11/16/30324.jpg
 ||soshuw.com/ui/bootstrap/base_
 ||soxs.cc/npm/vue.
-||srzc.com/images/*.swf
 ||ssyy121.com/js/bo
 ||ssyy121.com/js/di
 ||ssyy121.com/js/tonglan.js
@@ -9116,14 +8932,12 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||stcn.com/common/flash/aigu.swf
 ||steamcn.com/data/attachment/common/*.gif
 ||steamcn.com/img/
-||stnn.cc/images/xy/sfs
 ||storyren.com/images/dl
 ||storyren.com/imgg/
 ||suning.cn/uimg/cms/img/156758599903524618.jpg
 ||suv.cn/data/js/64.js
 ||suv.cn/data/js/86.js
 ||szkaidi.cn/statics/g
-||sznews.com/*.files/$image,object
 ||szonline.net/zhongyuan
 ||taipwl.com/yingshidaquan/popwin.js
 ||taiyingshi.com/js/960_
@@ -9136,52 +8950,29 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||tc.cn/news/images/right.jpg
 ||tengtv.com/skin/xin/Picture/img
 ||thcdy.co/baidu2/
-||thzok.com/6/
-||thzok.com/images/*.gif
 ||tiimg.com^*.gif
-||tiyuxiu.com/media/mm/
-||tmdm.tv/fgr/
-||tohomh123.com/js/funasd.js
-||toolfk.com/common/cp.js
-||toolfk.com/tools/images/vps/
-||toolnb.com/Public/aliyun/900x60.png
 ||torrentkitty.*/images/vpn
 ||torrentkitty.*/js/jquery.bpopup.
-||truvidplayer.com^$domain=ck101.com
 ||ts.cn^*/site1/$object
-||tt27.com/js/jsg/
 ||ttkyy.net/uploads/allimg/201710/1a13f1cdc0917406.jpg
 ||ttmgy.com/jstmp/as.js
 ||ttyavav.com/kanshenmekan/
 ||ttyavav.com/qian/
 ||tumb8r.com/zb_users/upload/20*.gif
 ||tuwandata.com/uploads/1907/17/731-1ZGG
-||tuyiyi.com/images/zone/201706/1-1F62G232310-L.png
-||tv1box.com/Runtime/Js/
-||tv432.com/templets/gg.js
-||tv887.com/js/pingbi.js
-||tvbwind.com/Public/90tvb/js/tvbwind.js
 ||twmeiju.com/images/axd.js
 ||txtshu365.com/img/
-||u.cnzol.com^
 ||uedfa.net/Static/imgs/affiliate/
 ||upload.jjxw.cn^*.swf
 ||uploads.duapp.com^$domain=52vip.net
-||usxpic.com/bit2019/upload/image/20191125/11251039541.gif
-||usxpic.com/bit2019/upload/image/20191125/11251039542.gif
-||usxpic.com/btimg/upload/image/20181018/101806323369.png
 ||v4.cc/m/common.js
 ||vgtime.com/game/cover/2019/11/28/191128172002163_u1477.jpg
 ||vipbuluo.com/2/123.png
-||vodxc.in/js/xccy/
-||vodxc.tv/js/xccy/
 ||vpsmm.com/tu/
 ||vsimg.com/jd.gif
 ||w3school.com.cn/ggk/
 ||w3school.com.cn/sp/
 ||w3school.com.cn/tg/
-||wan.sogou.com/static/fragment/
-||wanmcy.com/toolsda/
 ||wanyx.com/Public/js/qian.js
 ||webkaka.com/a/*-1100x50.
 ||whinfo.net.cn/ad20
@@ -9190,7 +8981,6 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||windows7en.com/statistics/stats.js
 ||wo256.com/256_gg/*.gif
 ||wo318.com/sjdy/
-||worldcup1.com^$domain=avcao.cc
 ||wpjam.com/wpjam/banner/qiniu.png
 ||wrltxt.com/hello/
 ||wwuuoo.com/11bb/
@@ -9198,12 +8988,10 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||wyb128.com/js/pc/
 ||wyh.tv/image/upload/ad/
 ||x7w7.com/js/float
-||x81zw.com/hf.js
 ||xgmeizi.com/smdd/
 ||xianzhenyuan.cn/data/attachment/common/
 ||xigua15.net/runtime/ajs/
 ||xinshijuecn.com/js/home/
-||xitangwenhua.com/muban/mh/js/asd.js
 ||xntk.net^*.html
 ||xrc3.com/js/floatcaoplus.js
 ||xunleige.com/js/functionx.js
@@ -9214,36 +9002,24 @@ $script,third-party,xmlhttprequest,domain=btio.pw
 ||xz7.com/js/jctj.js
 ||xz7.com/js/top2.js
 ||xz7.com/js/xia
-||y3600.com/1
-||ybbs.ca/index/js/advReplay_
 ||yhdm.tv/bar/
 ||yingshidaquan.cc/Templet/js/
 ||yktang8.com^*.gif
-||yorkbbs.ca/yorkads/
 ||you85.*/ling/
 ||you85.com/cy2/
 ||youth.cn^*.html$subdocument,~third-party
 ||youth.cn^*.php$subdocument,~third-party
-||youtube.com/embed/*&origin=$domain=ck101.com
 ||yundianb.com/hao/
 ||yundianb.com/tu/jia.gif
-||yunlaige.com/configs/article/*gg
-||yunlaige.com/configs/article/*zx
 ||yxdm.tv/js/*_
 ||yxdm.tv/js/gad.js
-||yy6080.cn/js/df.js
 ||yzpsb.com/1.js
 ||yzpsb.com/js/system.js
-||yzs.com/d/file/p/*.swf
-||yzs.com/d/file/p/2016/12/06/61e15b92a4a2a7cec4910f1d9ea79fb2.jpg
 ||zarvagroup.com/pcads.js
-||zb.cool/static/img/banner/
 ||zczj.com/special/
 ||zhangchengbo.com/meijuba/js/top.js
-||zhenjiang365.cn/bbsatt/day_120827/1208271004af7c25b6e3d4fa1d.gif
 ||zhgmeitu.xyz/images/*.gif
 ||zj.cn^*/AD?location=
-||zmzjstu.com/g3/tool
 ||zuoche.com/promo/*.jspx
 ||zzdaojia.com/mjs/
 hboav.com###AdTitle
@@ -9251,12 +9027,6 @@ hboav.com###AdTitle + table
 jiaodong.net###FixedLeft
 jiaodong.net###FixedRight
 rijutv.com###JU
-2345.com,hao774.com###J_act_plane_hb
-2345.com,hao774.com###J_search_bd > div:last-child
-yunlaige.com###PAGE_baidu_4
-yunlaige.com###PAGE_baidu_5
-sogou.com,soso.com###PZL
-sogou.com,soso.com###PZR
 jishujd.com,xiaokuangyl.com###ShouYe_ShangBu > .themeauthor > table:first-child
 70bt.cn###ShowAD
 ifeng.com###StreamMediaWrap
@@ -9271,7 +9041,6 @@ kiwsy.com.hk###ad-popup-dialog-overlay
 yuqingcn.cn###ad715x90
 vjmedia.com.hk###ad900
 plu.cn###adMask
-sogou.com###adWindow
 house.jschina.com.cn###ad_dl_left
 house.jschina.com.cn###ad_dl_right
 lzep.cn###ad_side_l
@@ -9281,32 +9050,24 @@ vip-free.com###adpic
 dm530.net,it168.com###adv
 nnfcxx.com###adv_3
 shurua.com###advbox
-ck101.com###av_a
 520cc.me###back-to-top > a[href^="http"]
 18avhub.com,18avtube.com,adultwefong.com,aicoin.net.cn,avmimi.com,fsdpp.cn,mm-cg.com,mse.360.cn,sports.qq.com,suopao.org,ting56.com,txzqw.me,youxi.baidu.com###banner
 mse.360.cn###banner0
 ballbar.cc,mse.360.cn###banner2
 mse.360.cn###banner_2
-sogou.com###bdfs0
 1kkk.com,dm5.com,dm5.hk,sfacg.com###beitou
 kyofun.com###bg_ad_left
 kyofun.com###bg_ad_right
 timedg.com###bigAdv
 vzhuan.cn###box
-hao.360.com###cangbao_redbags
-ck101.com###canvas-section
 cangku.in,galacg.me,moneyweekly.com.tw###carousel-example-generic
 qihoo.com###content_bottom_gg
 qihoo.com###content_bottom_left_gg
 qihoo.com###content_top_gg
 qq.com###coo_qqBrowser
-2345.com,hao774.com###corner_a
-2345.com,hao774.com###corner_div
 qihoo.com###countdown1111
 wpsoso.com###cse-search-box > p
 1fzdao.com###datu1
-sogou.com###detailRightAd
-ike.tv###divAds ~ a
 ref.so###div_midleft
 0562.cc,114shouji.com,1xlala.com,528500.com,52jscn.com,5378cc.com,5imx.com,99nets.me,bansha.com,bbs.52life.cc,chcj.com,cm868.com,cnyw.net,cqfishing.net,discuzlab.com,hh010.com,im286.net,kugz.com,ld0766.com,luanren.com,mahoupao.com,qilanxiaozhu.net,qinzhou8.com,sh419.net,suizhoushi.com,txahz.com,wishct.com,xsool.com,ybvv.com,ytshe.com###diy1
 1fzdao.com###diy123
@@ -9314,7 +9075,6 @@ cbber.com,you85.com###diy2
 cbber.com,qilanxiaozhu.net,xiaot.com###diy_chart
 storyren.com###diyfastposttop
 0517w.com,1xlala.com,365kl.net,3qled.com,52ch.net,bbs.qbaobei.com,chinafix.com,cnyw.net,cqsq.com,gz0668.com,mahoupao.com,mcncc.com,qilindao.com,xsool.com###diynavtop
-ttdytt.net###downlink
 zol.com.cn###downloader_main
 langxi.org###drk_ledtd
 bejson.com###dua
@@ -9324,25 +9084,20 @@ yzpsb.com###fc_foot
 1111.baidu.com,bdimg.com,tieba.baidu.com,tieba.com,xingqu.baidu.com###fixed_daoliu
 torrentkitty.app,torrentkitty.tv###fixedbanner
 rrys2019.com###float_ad
-123du.cc,bokon.net###float_r
 fulibus.net,wuzuowei.net###focusslide
 wcjbb.com###frame2TVWk2
 qhf168.com,qianhua.biz,qianhuaw.com###framelzHoHY
 downcc.com,pc6.com,zdfans.com###gaosuxiazai
 dilidili.one,zdzdm.com###gg
-sdgundam.cn###gg-banner
 vvshu.com###gg120
 1111.baidu.com,bdimg.com,tieba.baidu.com,tieba.com,xingqu.baidu.com###global_notice_wrap
 chaidu.com###hb
 pythontab.com###head-bottom
-solidot.org###headads
 lxty66.com###header + .tac.mb5
 pediy.com###header_right_cell[width="603"]
 bejson.com###headmedia
 moe-acg.cc###hengfu-widget
 w3cplus.com###home-page-widgets
-3987.com,588230.com###hongbao
-sogou.com###hotel_vr_details
 ifeng.com###hslide_sPic_360
 narutom.com###hy_float
 ifeng.com###ifengAehovering_small
@@ -9351,28 +9106,18 @@ rznews.cn###img
 narutom.com###itaTop
 letv.com###j-adr-playBT
 letv.com###j-bottomBanner
-sogou.com###kmap_business_title
-sogou.com###kmap_business_ul
-17ce.com###kr_wrap
 jobbole.com###leaderboard
-sdgundam.cn###left-sponsor
 cs.com.cn,cssqt.com,qinbing.cn,sonimei.cn###leftDiv
-timeon.cn###leftadv
 wed114.cn###leftdiv
 ifeng.com###leftdl
-leagueofmovie.com###leftfixedad
-www.wenxuecity.com###leftside
 dilidili.one,dilidili.wang###lgg
-sdgundam.cn###link-roll ~ .box-set-2
 uimaker.com###listbaidu
 ly6080.com###loginInfo > a
 letv.com###logo_activity
 dilidili.wang###m-box
-l114la.com###media
 hexieshe.cn###media_image-2
 avtb6677.com###menu-main-content > li:nth-child(n+5)
 jspoo.com###module2748
-pianyuan.net###myModal
 javjunkies.com###naked-ad
 narutom.com###naruto_desk
 dilidili.wang###newapp2018
@@ -9384,65 +9129,43 @@ rrys2019.com###output > li > a:not([href*="/resource/"]) + h2
 ifeng.com###picAdposition
 ahgame.com,china.com.cn,dandanzan.com,netbardh.com,pangzi.ca,twoeggz.com###pop
 2dfan.com###popadv-container
-ck101.com###popupGameAd
-17ce.com###pr_wrap
-tmsf.com###property_listf
 bbs.pcbeta.com###pt + div[style] > div[style^="clear:both;"]
 hcomic.in###pv_all > a[onclick^="trackOutboundLink"]
 cqsq.com###read_0 + a[target="_blank"]
-pujia8.com,sdgundam.cn###recommend
 ifeng.com###redbox
-2345.com,hao774.com###right > div:first-child
 cs.com.cn,cssqt.com,qiannao.com,qinbing.cn,sonimei.cn###rightDiv
 wed114.cn###rightdiv
 ifeng.com###rightdl
-leagueofmovie.com###rightfixedad
-www.wenxuecity.com###rightside
 jvhao.com###sAD3
 jvhao.com###sAD5
 javjunkies.com###sb1
 wpsoso.com###scontent > div[style]
 1111.baidu.com,bdimg.com,tieba.baidu.com,tieba.com,xingqu.baidu.com###search_baidu_promote
-liuli.pw###secondary img:not(.avatar)
-iplaysoft.com###section_event
 360-bo.com###selectpd
-5118.com###seobigdata_d1_text_seoreport
 ottawazine.com###sgpb-popup-dialog-main-div-wrapper
 paipai.fm###sideForum + div
 qiuquan.cc###sidebar .aligncenter
 5izyw.com###sidebar > .box-b:first-child
 iyejie.com,pc360.net###sidebar > .widget:first-child
 oneinstack.com###sidebar > .widget:last-child
-ainuody.com###sidebar > .widget:nth-child(-n+6)
 pc360.net###sidebar > .widget:nth-child(3)
 jobbole.com###sidebar > .widget_text:first-child
 cmsky.com###sidebar > .wow > .widget:first-child
 tl95.vip###sidebar > .wow:first-child > .widget:first-child
 jiecao123.com###sidebar > a
-iplaysoft.com###sidebar > ul > .widget:first-child
-iplaysoft.com###sidebar > ul > .widget:nth-child(3)
-iplaysoft.com###sidebar_scroll_bdad
 renrenfabu.com###sj-btn
 keke.la###slide:first-child
-12306.cn,club.pchome.net,kdslife.com###slideBox
-526bt.com###slider
 sogou.com###sogou_vr_10000901_0 > div[style="display:block;"]
-sogou.com###sogou_vr_21355601_wrap_0
 downbank.cn###speed-download
-sogou.com###tab857
 webkaka.com###tdMidPic
 ilvruan.com###text-11
 ilvruan.com###text-12
 moe-acg.cc,tumutanzi.com###text-3
-sogou.com###text_ad_area
 ref.so###tg2_main
 paipai.fm###the-logo + .fr
 1111.baidu.com,bdimg.com,tieba.baidu.com,tieba.com,xingqu.baidu.com###thread_list > .j_thread_list + li[class]:not(.j_thread_list)
 wpsoso.com###tips
-10.0.0.211###toolbar
 iyejie.com###top > div:not([id]):not([class])
-cctime.com,ck101.com,doyo.cn###top_banner
-tuyiyi.com###tuyiyi_zfb
 ifeng.com###veidoshowAd
 weishangshijie.com###wad_left
 weishangshijie.com###wad_right
@@ -9451,7 +9174,6 @@ xunleige.com###weizhi-a
 storyren.com###xydlleft
 storyren.com###xydlright
 rjfcxxw.com###yimao > div[style]
-cccpan.com,ys168.com###zdy_wz0
 dilidili.one,dilidili.wang##.A4
 china.com.cn,csdn.net,cyol.net,wxrb.com,yam.com##.AD
 le.com,letv.com##.Ad
@@ -9474,21 +9196,16 @@ ifeng.com##.FNewRAvtLisBox
 ifeng.com##.FNewRAvtLisBox02
 52fzwg.com,79tao.com,hqol.cn,mcncc.com,sunwy.org,twunbbs.com,wnflb.com,wnflb66.com##.GzList
 le.com,letv.com##.H-tg
-shenchuang.com##.MainR_ad3
 meijutt.com##.a960_index
 jdbbs.com##.a_h
 159i.com##.ac
 ifeng.com##.acAd1
 ifeng.com##.acPicBox
-2345.com,hao774.com##.act-search-tab
 0379home.com,2345.cn,234fang.com,265g.com,3gsc.com.cn,52youpiao.com,72g.com,9dcj.com,acg.bz,acg13.cn,acgbenzi.com,baiduyunpan.net,baike.com,bbs-mychat.com,cdyee.com,ce.cn,chddh.com,chinaiiss.com,chinaqking.com,chinatimes.com,chinatruck.org,chinaz.com,cnforex.com,cnsoftnews.com,codepub.com,cq.xinhuanet.com,cxryun.cn,dav01.com,discuss.com.hk,djwma.com,dmzj.com,douban.com,dzwww.com,eastday.com,fengniao.com,focus.cn,fx112.com,gongkong.com,henan100.com,honglingjin.co.uk,house.jschina.com.cn,iciba.com,ifeng.com,ipeen.com.tw,isharebest.com,itavcn.com,jiligame.com,jrj.com.cn,kumi.cn,landiannews.com,lawtv.com.cn,lieyunwang.com,loveshang.com,luo8.com,lyd.com.cn,lyreader.com,lzep.cn,maxpda.com,mm111.net,moxing.net,ncdiy.com,neotv.com.cn,newsmth.net,njdaily.cn,olevod.com,people.com.cn,pharmnet.com.cn,pixnet.net,pptv.com,ptbus.com,qihaa.cn,r3sub.com,shenchuang.com,sj998.com,sogou.com,sozi.cn,titan24.com,toocle.com,tpy888.cn,tv.sohu.com,u-car.com.tw,wallstreetcn.com,weather.com.cn,xs99.cc,xun9u.com,xyfdcw.com.cn,yawin.cn,yb983.com,ydss.cn,yesky.com,yqxs.net,zjstv.com##.ad
 photofans.cn##.ad-1-index
 cangku.in,cangku.moe,enjoymore.fun,got001.com,iwan.baidu.com,qq.com,qtv.com.cn,xinhuanet.com,zol.com.cn##.ad-box
 newtalk.tw,toolfk.com##.ad-container
-olevod.com##.ad-corner
-sogou.com##.ad-img-bt + .picContainer
 baidu.com,ifeng.com##.ad-list
-feng.com##.ad-list-item
 dilidili.wang##.ad-middle
 zol.com.cn##.ad-soft-box
 10jqka.com.cn,88files.net,99files.net,actoys.net,beijing-air.com,bio1000.com,gter.net,hepuwang.com,jjwxc.net,ncdiy.com,qingdaonews.com,tgbus.com##.ad1
@@ -9501,10 +9218,8 @@ nmgnews.com.cn,sj998.com,sportscn.com,tpy888.cn##.ad3
 jokeji.cn##.ad3602
 tpy888.cn,weather.com.cn##.ad4
 sj998.com##.ad5
-china.com.cn##.ad6
 juyouqu.com##.ad630
 ifeng.com##.ad665
-ting89.com##.ad7
 ifeng.com##.ad728_tit
 newcger.com##.adFullwidth90
 ifeng.com##.adL660
@@ -9514,10 +9229,7 @@ ifeng.com,nnnews.net##.ad_12
 nnnews.net##.ad_24
 ttys5.com##.ad_580
 huanqiu.com,tpy888.cn##.ad_all
-sogou.com##.ad_aside_inner
 ifeng.com##.ad_btn
-hc360.com##.ad_left
-ck101.com##.ad_logo
 letv.com##.ad_pop
 letv.com##.ad_pop_small
 bitauto.com,cnblogs.com,hc360.com##.ad_right
@@ -9525,7 +9237,6 @@ stheadline.com,yinyuetai.com##.ad_w300
 ifeng.com##.adcoop
 jgzj.net##.adcss
 uzzf.com##.address_like:nth-child(-n+7)
-ck101.com##.adfixWp
 ifeng.com##.adimg
 sina.com##.aditem
 jxedt.com##.adlink1
@@ -9544,15 +9255,12 @@ ce.cn,chinabidding.com.cn,eastmoney.com,ieforex.com,laod.cn,xywy.com,zhujiceping
 sspai.com##.advert-card
 aicoin.net.cn,bccn.net,hkepc.com,iviewui.com##.advertisement
 afzhan.com,cngold.org,panjin.net,qq.com,tongxiang.net##.advs
-jszbug.com,siku11.com##.alert-danger
+jszbug.com##.alert-danger
 iviewui.com##.asd
 vpsmm.com##.aside-widget > :nth-last-child(n+3)
 acgking.com##.asst
-bing.com##.b_ad
-bing.com##.b_adBottom
 0du123.com,24en.com,3gsc.com.cn,591hx.com,5g0a.com,acgnx.se,aguitar.cn,btzx2017.com,e0514.com,eastmoney.com,guitarchina.com,gz0668.com,hk.on.cc,iciba.com,iguaji.com,iqiyi.com,jia360.com,joy.cn,kdnet.net,kumi.cn,manyuancs8.xyz,newnet.cc,rain2.top,tiboo.cn,toocle.com,wallstreetcn.com,xingkbjm.com,xizi.com,zgfznews.com,zyue.com##.banner
 big-cup.tv,g-cup.tv##.banner-table-block
-5118.com##.banner-top
 jinse.com##.banner1200_new
 chinaiiss.com##.banner_middle
 sznews.com##.banner_new2
@@ -9560,17 +9268,14 @@ news.lzep.cn##.basehr + div:nth-child(3)
 newnet.cc##.bdad1
 3h3.com,veryhuo.com##.bendown
 jrj.com.cn##.bg2424
-sogou.com##.bizr_rb
 tvsou.com##.border-btn[style^="height:"]
 kt51.com##.bottom_fixed
 freehao123.com##.box
 le.com,letv.com##.broadcast-adv
 ifeng.com##.btm_tg
 zdfans.com##.btn + .btn
-ucbug.com##.bzClick
 qihoo.com##.car-ercode
 btring.com##.card[target="_blank"]
-2345.com,hao774.com##.chc-dzoem
 hboav.com##.close_box
 hboav.com##.close_box0
 www.wenxuecity.com##.col > ul:not([id]) > li > a[href^="http://"]:not([href*=".wenxuecity."])
@@ -9578,14 +9283,8 @@ joy.cn##.con2-3
 rijutv.com##.container > div[style="height: 128px;"]
 it1352.com##.container-fluid > .hidden-sm:nth-child(-n+2)
 w3cschool.cn##.content-abox
-hao.su##.content-copyright
-tuchong.com##.contribute-show
-51.com,wnacg.org##.couplet
 vuetifyjs.com##.d-inline-block
-iplaysoft.com##.d250
-czjx8.com##.desc
 toocle.com##.detail_top_ad
-dismall.com##.df_money
 0597ok.com##.div_ad
 pc0359.cn##.dl-down
 pc0359.cn##.dl-ico:nth-child(-n+7)
@@ -9597,12 +9296,8 @@ pc0359.cn,pc6.com,ucbug.com##.downnow
 cr173.com,downcc.com##.downnowgaosu
 jinbaozy.com##.dtk-fixed-ads
 chaomi.cc,cpnn.com.cn,cs.com.cn,dyhjw.com,kkj.cn,my0538.com,mydrivers.com,ofweek.com,silver.org.cn,ttzmz.vip,wendu.cn##.duilian
-solidot.org##.e_reply > .fr
 dilidili.wang##.elmnt-one > .shade > a[href^="http"]:not([href*=".dilidili."])
-1point3acres.com##.enhanced_header
 idanmu.at##.entry-body > div[class]:first-child
-2345.com,hao774.com##.event1-hasList
-duote.com##.fast-down-btn
 uzzf.com##.fastdownload
 jjmmw.com##.fixed-ad
 lyreader.com##.fixnewUser
@@ -9610,14 +9305,10 @@ lyreader.com##.fixnewUser
 taoyizhu.com##.float-banner
 hoteastday.com##.float_ad
 rrys2019.com##.float_middel_ad_bk
-pic.sogou.com##.floating
 newcger.com##.focus + .block934
 pcbeta.com##.forum_top ~ div[class]
 vvshu.com##.forviewda
-ainuody.com##.full-width
 quanmin.tv##.g-gg
-sogou.com##.game-op
-timeon.cn##.gameads
 onlinedown.net##.gaosu
 3h3.com##.gaosu_down_div
 1kkk.com,40407.com,5068.com,88148.com,chazidian.com,china.com,cnwnews.com,elecfans.com,ghjie.com,iask.ca,ifeng.com,iqilu.com,jj59.com,juqingba.cn,qzwb.com,sina.com.cn,tianya.cn,zsnews.cn##.gg
@@ -9632,27 +9323,21 @@ laixoo.com,zhumengwl.com##.git_banner
 veryhuo.com##.gs
 ddooo.com##.gsbtn
 ddooo.com##.gsbtn1
-yxdown.com##.gsdown
 33lc.com,cncrk.com##.gsdt
 pcsoft.com.cn##.gsxz
 97aa1.com,niu20.com##.guang4
 adreep.cn,baoliny.com,gasaq.com,hgitv.com,ifooday.cn,nen.com.cn,rznews.cn##.guanggao
 shm.com.cn##.guanggaowei2
 shm.com.cn##.guanggaowei3
-ck101.com##.hd-bgimg
 weishangshijie.com##.head_0905
 doupapa.com,dpp2019.com##.hidden-xs[class*="_"]
 9553.com##.high-down
 orsoon.com##.high-downs
 orsoon.com##.hongbao
-sogou.com##.hotel-pic
-sogou.com##.hotel_tit
-sogou.com##.hotel_tj
 skinme.cc##.huodong
 yzpsb.com##.hy-details-qrcode
 ifeng.com##.ifgBoxAdLis
 ifeng.com##.iggLine
-5555op.com##.img
 1avlang.com,avlang.com,avlang13.info##.index-info > .tac
 cqsq.com,jisuxz.com,jmnews.com.cn##.index_banner
 hgitv.com,wo256.com##.index_gg
@@ -9677,7 +9362,6 @@ ahtv.cn,bzfl1.cc,sexbarss.net##.l1
 p4vip.com##.leaveNavInfo
 bejson.com##.left.validate + div
 zimuku.cn##.li[style^="width:8"]
-5118.com##.lianmeng-home-header
 news.ifeng.com##.list022
 uimaker.com##.listads
 jrj.com.cn##.ls_all_fc
@@ -9687,15 +9371,10 @@ zhicheng.com##.mad_bt
 zol.com.cn##.member-button-yellow
 cangku.in,galacg.me,llss.li,usnewsexpress.com##.metaslider
 360-bo.com##.middiv > div[style="text-align:center;"]
-2345.com,hao774.com##.mod-txtred
-pianyuan.net,qixingquan.com##.modal-backdrop
-xunyingwang.com##.modal-body
 moonbt.com##.money_all
 xbooks.to##.movie-in-ad
 newcger.com##.mtb17.h90
 cqsq.com##.mumucms_index_tlad
-2345.com,hao774.com##.mzdh_bottom
-moyu16.com##.nav-banner
 maplestage.com##.nav-left-module__info-wrapper___35CLR
 tpy888.cn##.nead
 zhicheng.com##.newa2
@@ -9721,28 +9400,23 @@ ifeng.com##.pao_ad_03
 ifeng.com##.pao_mid
 ifeng.com##.pao_mid_02
 sodao.com##.photo-see > div[style="text-align: center; margin-bottom: 10px;"]
-tv.52pili.com##.pic-box
 ifeng.com##.pic280
 ctrip.com##.pic_banner
 chinaiiss.com##.pic_text
 news.ifeng.com##.play_center
 moonbbs.com##.plc.plm > div > div > a[href*=".dealmoon.com"]
-eol.cn,hao123.com,site.baidu.com##.popup
 jobbole.com##.post > .textwidget
 jobbole.com##.post-adds + .textwidget
-hao.su##.post-content > div[class^="a"]
 sanv.org##.post-left
 ihacksoft.com##.post-top-gg
 huaban.com##.promotion
 ifeng.com##.pullClient
 or123.top##.qfe_wrapper > div > a[href^="http"]:not([href*="or123."])
-czjx8.com##.qktz
 ifeng.com##.qudaoTg
 ahtv.cn,bzfl1.cc,sexbarss.net##.r1
 yuqingcn.cn##.rboxad
 finance.ifeng.com##.rec
 image.baidu.com,xizi.com##.recommend
-0597kk.com##.recommend-container
 tvsou.com##.recommend-img
 le.com##.recommend-part-right
 w3cplus.com##.region-sidebar-second > :nth-last-child(n+3)
@@ -9751,21 +9425,15 @@ hao123.com##.rightTip
 sznews.com##.right_flash
 dilidili.wang##.right_top_ad
 jjxw.cn##.ru_banner
-xiazaiba.com##.sdown-item:first-child
 pediy.com##.search
-duba.com,newduba.cn,timeon.cn##.search_promotion
 ottawazine.com##.sgpb-popup-overlay
 jianshen8.com##.sidebar > a
-juejin.im##.sidebar-bd-entry
-pic.sogou.com##.sidebar_box.shut
 youtaoqi.com##.sidetg
 mopxing.com##.sideul1
-15yc.cc##.site_tips
 uimaker.com##.siteads
 ifeng.com##.slide_popo_modal
 pdflibr.com##.sms-content-ad
 northnews.cn##.sponsor02
-sogou.com,soso.com##.sponsored
 acwifi.net##.ssr
 ifeng.com##.swiper-bottom
 vdianying.cc##.swiper-container
@@ -9779,12 +9447,9 @@ jxedt.com##.tbad
 srzc.com##.tcck1
 srzc.com##.tcck2
 newmobilelife.com##.td-a-rec-id-content_inline
-yorkbbs.ca##.textNewsBorder
 526bt.com,eroacg.com,laod.cn,ninpang.com,xiaohutuwb.com,zhujiceping.com##.tg-site
 dlemm.cn##.themead
-2345.com,hao774.com##.tip_stopXP
 zhujiwiki.com##.tips
-2345.com,hao774.com##.top > .fred
 ifeng.com,nen.com.cn,sina.com,sina.com.tw,weibo.com##.topAd
 sxclub.net##.topAdv
 40407.com,qudong.com,xitong8.com,xt700.com##.top_banner
@@ -9794,9 +9459,6 @@ ifeng.com##.top_carousel
 ofweek.com##.ui-slider
 rijutv.com##.union-list-item
 bejson.com##.validateButtons.clear a
-ck101.com##.videoADImg
-ck101.com##.videoFocus
-ck101.com##.viewthread-leftfloatbox
 sogou.com##.vr-pop-ups > .pop-div
 quanmin.tv##.w-newhot_slot-wrapper
 web20share.com##.widget:nth-of-type(5)
@@ -9816,7 +9478,6 @@ wanyx.com##.xz_down
 moviesunusaaa.org##.yahooinner
 techweb.com.cn##.yaowen > ul > a[style="display:block;position:relative;"]
 pc0359.cn##.yinsu_yd
-geilwx.com##.yueduads
 fx168.com##.yy_guangao
 qizuang.com##.zb_footer_box1
 qizuang.com##.zb_footer_box_little
@@ -9826,7 +9487,6 @@ ifeng.com##[id^="cl"]
 ddooo.com##[onclick*="soft.ddooo."]
 lyreader.com##[onclick^="loadDownloadAPP"]
 duodada.com##[style^="width: 100%; height: auto; position: fixed;"]
-5dm.tv##a > img[src*=".sinaimg."]
 acgnx.se##a > img[src^="/images/"]
 onlinedown.net##a.qrcode_show
 ditu.so.com##a[class^="index-bcItem-"]
@@ -9834,60 +9494,38 @@ dilidili.wang,~h5.dilidili.wang##a[href*=".11h5."] img
 quanmin.tv##a[href*=".2144.cn/"]
 boke112.com,techweb.com.cn##a[href*=".aliyun.com"]
 cnbeta.com##a[href*=".ctyun."]
-ctfile.com##a[href*=".henghost.com"]
 hanjutv.com##a[href*=".hujiang.com"]
 dapenti.com,douyu.com,iqiyi.com,jinti.com,v.qq.com##a[href*=".jd.com"]
 ed2000.com##a[href*=".lanzous.com/"]
-apprcn.com,yeyulingfeng.com##a[href*=".lizhi."]
-mumujita.com##a[href*=".makeding.com/"]
 torrentkitty.app,torrentkitty.tv##a[href*=".nordvpn.net/"]
 ifeng.com##a[href*=".sm.cn"]
 52movieba.com,acglala.net,ainuody.com,awaker.cn,cangku.in,ccav1.com,cdsoso.me,cgown.com,cn163.net,cosersuki.org,epinv.com,eroacg.com,galacg.me,gmgard.com,haochi123.com,hcomic.in,hexieshe.cn,hexieshe.com,hexieshe.xyz,hggard.com,hmghmg.com,hmog.me,htcui.com,huan.moe,idanmu.at,jiecao123.com,jitapu.com,jiyingw.net,jobbole.com,kisssub.org,languang.co,liuli.pw,moe-acg.cc,moe-acg.us,mydrivers.com,nxing.cn,oyksoft.com,rijutv.com,souxue8.com,speedtest.cn,toutiao.com,tucao.one,vpansou.com,xxshe.info,xxshe.xyz,youku.com##a[href*=".taobao.com"]
 acgdoge.net,chinalawedu.com,douyu.com,gmgard.com,hggard.com,iqiyi.com,jinti.com,youku.com##a[href*=".tmall.com"]
 ifkdy.com##a[href*=".yhm11.com"]
-cnzol.com##a[href*=".youa.net"]
-instrument.com.cn##a[href*="/ad/"]
 dilidili.wang##a[href*="Game"]
 bejson.com##a[href*="aliyun"]
-r3sub.com##a[href*="bit.ly"]
-v.sogou.com##a[href*="iwan.sogou.com/"]
 ifeng.com##a[href*="popoxiu.com"]
 ifeng.com##a[href*="popoxiu.com"] + h3
 ifeng.com##a[href*="popoxiu.com"] + h3 + p
 kukudm.com##a[href="/exit/exit.htm"] > img[src="/images/d.gif"]
 bejson.com##a[href="/tolayui.php"]
-moyu16.com##a[href="http://71979.com"]
 bejson.com##a[href="http://www.bejson.com/apidoc/jquery/"] ~ a
 bejson.com##a[href="http://www.bejson.com/apidoc/jquery/"] ~ p
 bejson.com##a[href="http://www.bejson.com/ui/tuchuang/"] ~ a[style]
-ainuody.com##a[href="http://www.zhuzhuquan.com.cn"]
 wandhi.com##a[href="http://www1.huizhek.com"]
-sdgundam.cn##a[href^="/aclk/"]
-x6d.com##a[href^="/ad.php?"]
-liuli.pw##a[href^="/gg2/"]
 jishujd.com##a[href^="http"]:not([href*=".jishujd."]) > img[src^="/upload/1/"]
 qqhzg.com##a[href^="http"]:not([href*=".qqhzg."]) > img[src^="/upload/1/"]
 xiaoheizy.com##a[href^="http"]:not([href*="xiaoheizy.com"]) > img
 moe-acg.cc##a[href^="http://game.moehuan.com/"] > img
 pctowap.com##a[href^="http://ptw.la/"]
-yeyulingfeng.com##a[href^="http://woaigouwu.top"]
 jcrb.com##a[href^="http://www.abchina.com/"]
 cjjjs.com,fastadmin.net##a[href^="https://promotion.aliyun.com/"]
 shufazidian.com##a[href^="https://weidian.com/"]
-5118.com##a[id][href^="http"]:not([href*=".5118.com"]) > img
-5118.com##a[id^="default-"]
-5118.com##a[id^="home-"]
 360-bo.com##a[name="thegg"]
 5g0a.com##a[onclick*="banner"]
 tvapk.net##a[onclick*="thread_banner"]
 hanjutv.com##a[style="width: 1120px;height: 70px;overflow: hidden;display: block;"]
-18board.com,18p2p.com##a[target="_blank"] > img[width="320"]
-18board.com,18p2p.com##a[target="_blank"] > img[width="330"]
-18board.com,18p2p.com##a[target="_blank"] > img[width="728"]
 idanmu.at##aside > div[class="widget "]
-anjuke.com##div[class$="-ad"]
-2345.com,hao774.com##div[class*="act-navspec"]
-autohome.com.cn##div[class*="game"]
 moonbt.com##div[class="box mb"] > a
 chengdu.cn,oeeee.com##div[class^="ad-"]
 16668.biz,16668.cc,16668.com,16668.info,16668.net,16668.org,16668tu.com,alibuybuy.com,chewen.com,faloo.com,newhua.com,ph66.com,tv.cntv.cn##div[class^="ad_"]
@@ -9895,45 +9533,35 @@ whinfo.net.cn##div[class^="adw"]
 jj59.com##div[class^="art_a"]
 zol.com.cn##div[class^="box-top-xiaza"]
 orsoon.com##div[class^="down-sect"]
-syd.com.cn##div[class^="eap"]
 idanmu.at##div[class^="g "]
 jzhome.cn##div[class^="main_gg"]
-sogou.com##div[class^="rt-gameright"]
 narutom.com##div[class^="wrap2 vtg"]
 zhihu.com##div[data-za-detail-view-path-is_ad]
 mail.126.com,mail.163.com##div[id$="_dvBlockInfo"]
 mcdulll.com,pixnet.net##div[id*="-ad-"]
 feiwan.net,kcili.com##div[id*="_"][style]
 iqiyi.com##div[id^="100000"]
-2345.com,hao774.com##div[id^="J_Topic"]
 makepolo.com,mycar168.com,mysteel.com,pchome.net,qz828.com##div[id^="ad"]
 shm.com.cn##div[id^="baidu_clb_slot_"]
 doyo.cn,keleyi.com,lgmi.com##div[id^="gg"]
 51240.com##div[id^="ggwz"]
 fx110.com##div[id^="ghz"]
-tyenews.com##div[id^="media_image-"]
 ddrk.me##div[id^="zmda"]
 avonline.org##div[style$="width:570px;margin-left:50px;"]
 dfpan.com##div[style*="img.com/"]
-iplaysoft.com##div[style*="width:3"][style*="height:2"]
-iplaysoft.com##div[style*="width:6"][style*="height:1"]
 pythontab.com##div[style="margin-bottom: 4px;"]
-iplaysoft.com##div[style="margin:-10px 0 0 0;overflow:hidden"]
 kaifu.tw##div[style="margin:15px; padding:2px;width:304px; height:254px; clear:both; margin:5px auto 20px;"]
 tucao.one##div[style="margin:auto;margin-top:0px;width:964px;height:105px;"]
 ref.so##div[style="overflow:hidden; height:auto; width:1002px; margin:0 auto;  "]
 0573ren.com##div[style="width:1000px; margin:10px auto; background:#F8F8F8"]
 xbooks.to##div[style="width:900px; height:250px; margin: -15px auto 15px auto;"]
-stnn.cc##div[style="width:960px;height:90px;float:left;"]
 pc360.net##div[style^="border:none;height:90px;width:728px;"]
 zimuku.cn##div[style^="position:fixed; text-align:"]
 ieche.com##div[style^="width: 298px;height:250px;"]
 pc0359.cn##div[style^="width:301px;height:250px;"]
 avonline.org##div[style^="width:613px; height:"]
 zimuku.cn##div[style^="width:8"]
-moyu16.com##img[height="85px"]
 nicemoe.com##img[src*=".sinaimg."][style="width:100%;margin-top:0px;"]
-moyu16.com##img[style="width:1238px;height:100px"]
 javjunkies.com##img[width="160"][height="600"]
 gpshk.cc##img[width="770"]
 chcj.com,pt80.net##img[width="960"]
@@ -9945,39 +9573,27 @@ power.baidu.com,zhidao.baidu.com##style[id^="s-m"] + div[id^="m"]
 pt80.net##table[cellpadding="2"][bordercolor="#DFC5A4"]
 jdbbs.com##table[cellspacing="5"][bordercolor="#9dbedd"]
 28xl.com##table[style^="width:678px; height:280px;"]
-cartonmad.com,cartoomad.com##table[width="728"][height="110"]
-cartomad.com,cartoonmad.com##table[width="737"] > tbody > tr > td[valign="top"][height="118"]
 pt80.net##table[width="760px"]
 you85.cn##table[width="980"]
-51credit.com,ck101.com,hkepc.com##tbody[id^="normalthread_"] + tbody:not([id])
 cartomad.com,cartonmad.com,cartoonmad.com,comicnad.com,conicsmad.com##td[align="center"][height="102"]
-cartoonmad.com##td[width="890"] > table > tbody > tr > td[valign="top"][height="118"]
-cartoomad.com##tr:last-child > td[align="right"] > table[width="732"]
-sogou.com##ul[class^="atAd"]
 wangnba.com#@##adSet
 timesdata.com#@##adbody
 hongrentao.cc,houhuayuan.pink,mcfuns.com.tw,mrmad.com.tw,myself-bbs.com,paltv.top,pbhz.com,sportsyeah.hk,ugediao.com,xingkbjm.com,youneed.win,zhaoze.party,zhuihd.com#@##adsense
-soft.macx.cn,tunesp.com#@##googlead
 29yyl.com#@##index_ad
 wangnba.com#@##showAd
 520cc.cc,520cc.me,5278.cc#@#.a_cn
-520cc.me,sewangchao.com,sewangchao3.com#@#.a_mu
 mobile01.com#@#.ad-a
 pdflibr.com#@#.ad-center
 liumingye.cn#@#.ad-column
 digitalocean.com#@#.ad-content
 mucanwenxue.com#@#.ad250
-520tingshu.com,ting35.com#@#.ad960
-cw.com.tw#@#.adActive
 macwk.com,poedb.tw#@#.adBanner
 workercn.cn#@#.ad_content
 poba.com.tw,poba.hk#@#.adlist
-159i.com,techroomage.com,zhaopin.com#@#.adsBox
 liumingye.cn#@#.adsTest
 alotof.software,android-doc.com,apk.tw,battlecats-db.com,chtoen.com,dizhishengcheng.com,doitwell.tw,epinv.com,ff14angler.com,fxpan.com,haoweichi.com,moa.tw,numberempire.com,playok.com,shenfendaquan.com,tingfm.com#@#.adsbygoogle
 liumingye.cn#@#.advText
 8maple.ru,bilibili.to,oldpig.org,pron777.com#@#.afs_ads
-10.10.5.12#@#.banner_ad
 btbt.tv#@#.google-ad
 wangzheli.com#@#.headad
 hbee.edu.cn#@#.headerad
@@ -9997,7 +9613,7 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 @@/advertisement_ads_$domain=pdawiki.com|tahua.net
 @@/adview_pic_$domain=2hanju.com|laimanhua.com|lingjike.com|mahua.com|meiyouad.com|mh160.com|reh.tw|silisili.me|xiaoz.me|ykit.cn|zgpingshu.com
 @@/fingerprint2.$domain=nfmovies.com
-@@/fuckadblock.$domain=bde4.com|ck101.com|datehub.co|dilidili.one|golangnote.com|lnk2.cc|nfmovies.com|papalah.com|qqdie.com
+@@/fuckadblock.$domain=bde4.com|datehub.co|dilidili.one|golangnote.com|lnk2.cc|nfmovies.com|papalah.com|qqdie.com
 @@/images/*/*.gif$domain=maichun5.info|mc88.info|myhhg.com|yh1.info|yh10.info
 @@/images/ad/*$domain=9588.com|casio.com.cn|dod-tec.com|jxedt.com|ourgame.com|pro-partner.com.tw|snh48.com|tingbook.com
 @@/modules/ads/*$domain=shopee.tw
@@ -10010,19 +9626,15 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 @@||51jobcdn.com/im/images/ads/$domain=51job.com
 @@||520cc.cc/ad*.js
 @@||5278.cc/static/image/common/ad_close.gif
-@@||5w8s.com/myads/img/otherwp.gif
-@@||5w8s.com^*/thunder$image
 @@||aixifan.com/static/css/advertisement_
 @@||alotof.software/wp-content/themes/alosss/ads.php
 @@||apk.tw^$script,~third-party
 @@||bingfeng.tw/data/attachment/common/ad/common_ad_icon.png
 @@||bootcss.com^$script,domain=bimibimi.tv|kan-tv.com|wnacg.com
-@@||cdn.staticfile.org^$script,domain=manhuadui.com
 @@||chdbits.co/pic/cattrans.gif
 @@||chdbits.co/pic/trans.gif
 @@||cpro.baidustatic.com/cpro/ui/$domain=www.pctowap.com
 @@||dilidili.one^$generichide
-@@||edu.cn/epstar/*/gg/
 @@||exoclick.com/iframe.php?*=2596969&$domain=jav777.cc
 @@||exosrv.com/iframe.php?*&size=300x250$domain=520cc.cc|520cc.me
 @@||googletagservices.com/tag/js/gpt.js$domain=tvb.com
@@ -10032,10 +9644,8 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=4gtv.tv|881903.com|appledaily.com|linetv.tw|mytvsuper.com|nextmedia.com|now.com|tvb.com|udn.com|xuite.net
 @@||jdfood.com.tw/Upload/ADImages/*Image.jpg
 @@||jinhongweiqi.com/ad/update/
-@@||jrhot.com/data/attachment/*_300_250_
 @@||league-funny.com^$generichide
 @@||league-funny.com^$script,~third-party
-@@||leagueofmovie.com^$generichide
 @@||linetv.tw/public/scripts/ads.js
 @@||mediav.com/js/feed_ts.js$domain=toutiao.china.com
 @@||moviesunusa.net^$generichide
@@ -10048,27 +9658,16 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 @@||securepubads.g.doubleclick.net/gampad/ads?$domain=league-funny.com
 @@||securepubads.g.doubleclick.net/gpt/pubads_impl_$domain=league-funny.com
 @@||serve.netsh.org^$elemhide
-@@||taihainet.com^*/thumb_300_250_
-@@||thu.edu.tw/upload/ad_upload/
 @@||timesdata.com/Public/*/ad$~third-party
 @@||tvb.com/player/*/videojs.ads.
 @@||tw.m.yimg.com/res/ads/$domain=tw.buy.yahoo.com
 @@||wubisheng.net^*.js
-@@||x81zw.com/images/all.gif
 @@||yimg.com/ud/fp/js/Ads.*.min.js$domain=mobi.yahoo.com
-7255.com###J_search_bd > div:last-child
-7255.com###right > div:first-child
-7255.com##.act-search-tab
-7255.com##.chc-dzoem
-7255.com##.mod-txtred
-7255.com##.mzdh_bottom
-7255.com##div[id^="J_Topic"]
 ||gif|$domain=99a25.com|xin99r3.com|xin99r4.com
 99a25.com,xin99r3.com,xin99r4.com##.dmcenter
 99a25.com,xin99r3.com,xin99r4.com##.spots
 ||alicdn.com^$domain=99a25.com|xin99r3.com|xin99r4.com
 ||sinaimg.cn^$domain=99a25.com|xin99r3.com|xin99r4.com
-||immedlinkum.info^
 ##div:not([id]):not([class]):not([style]) > div:not([id]):not([class]):not([style]) > iframe[scrolling="no"][src*="//"][src*="?"][src*="="][src*="&"][width][height][frameborder="0"]:not([src^="http://www.facebook.com/"])
 ##div[style^="width: 100%;"][style$="display: block;"] iframe[scrolling="no"][src*="//"][src*="?"][src*="="][src*="&"][width][height][frameborder="0"]
 ?*=*=*=$subdocument,domain=00cha.com|01fy.cn|06ps.com|08160.cn|0s.net.cn|10000xing.cn|1010jiajiao.com|1024sj.com|11467.com|114piaowu.com|120ask.com|16xx8.com|192ly.com|1ting.com|201980.com|23yy.com|256.cc|263y.com|2hanju.com|2liang.net|315hyw.com|3199.cn|32xp.com|3454.com|360changshi.com|360doc.cn|360zuowen.com|39.net|39yst.com|4aqq.com|515fa.com|51edu.com|51sxue.com|51test.net|51zxw.net|52che.com|52qj.com|52wubi.com|52zxw.com|59wz.com|5djiaren.com|5h.com|5nd.com|5seestar.com|5tps.com|5ykj.com|66law.cn|66wenshen.com|6822.com|7k7k.com|7y7.com|86huoche.com|8794.cn|911cha.com|91jucai.com|91zhongkao.com|949949.com|9553.com|9939.com|9ht.com|ab126.com|admin5.com|aihami.com|aiyangedu.com|aizhan.com|ankangwang.com|apple886.com|arpun.com|askci.com|aspku.com|atobo.com|baoxianzx.com|blog.sina.cn|chajiaotong.com|chazidian.com|coozhi.com|d1xz.net|daquan.com|dgzj.com|dugoogle.com|faxingzhan.com|fun48.com|hqhot.com|huangye88.com|hydcd.com|icauto.com.cn|isanxia.com|ixinwei.com|jianbihuadq.com|jiazhao.com|jingdianlaoge.com|liuxue86.com|m.douban.com|makepolo.com|mama.cn|mipcache.bdstatic.com|mmonly.cc|pctowap.com|pingshu8.com|riji.cn|riji100zi.com|rr95.com|shangc.net|tianya999.com|weather.com.cn|win7sky.com|woyaogexing.com|xiachufang.com|xiangha.com|xiaole8.com|xinwenlianbo.tv|yiqig.cn|zhifure.com|zhongyoo.com|zjbiz.net|zuowen8.com|zuowenku.net|zuowenwang.net
@@ -10085,7 +9684,6 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 ||1.proewildfire.cn^
 ||1.snzfj.net^
 ||1.tongquee.com^
-||1.wenzhangba.cn^
 ||123.39jz.com^
 ||4name.com^$third-party
 ||52linglei.com^
@@ -10123,7 +9721,6 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 ||c.xiaobaipan.com^
 ||chicken18.com^
 ||chuangyixi.com^
-||cj1.256.cc^
 ||code.tui80.com^
 ||codeym.dictall.com^
 ||d*.wanzhuang.com^
@@ -10140,10 +9737,8 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 ||dm1.yongkao.com^
 ||dmsz.win7sky.com^
 ||dzais.com^
-||f*.baidu.com/it/u=*,*&fm=$third-party,domain=~hao123.com
 ||f1.lutouwang.net^
 ||fbmjc.39yst.com^
-||feidalu.com^
 ||forad1.weimeicun.com^
 ||fpb1.gxfin.com^
 ||fpbcode.onlinedown.net^
@@ -10156,7 +9751,6 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 ||gzcl999.com^
 ||hao1.loxue.com^
 ||hiorange1.jobui.com^
-||idgdmgroup.com.cn^$third-party
 ||ixpub.net^*.js
 ||jiaoben.webkaka.com^
 ||jinshui2018.chalook.net^
@@ -10168,16 +9762,13 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 ||js1.xbaixing.com^
 ||jsm.39yst.com^
 ||kuhou.com^$third-party
-||m1.dxsbb.com^
 ||m1.hapi123.net^
 ||mad1.jirou.com^
 ||mf01.zybang.com^
 ||miyudaquan.top^$third-party
 ||mn586.com^$third-party
 ||modzj.net^$third-party
-||mps.yuwenba.cn^
 ||mssheng.com^
-||mt.59wz.com^
 ||mxitie.com^$third-party
 ||mzcsdf.com^$third-party
 ||nba.emohe.com^
@@ -10186,7 +9777,6 @@ bee.coupons,blogspot.com,blogspot.hk,blogspot.jp,blogspot.tw,comic.tw,jasonblog.
 ||qcjslm.com^
 ||qq167.com^
 ||quyaoya.com^$third-party
-||rbmry.com^
 ||ruan88.com^
 ||s1.dapenti.com^
 ||s1.wan1979.com^
@@ -10221,23 +9811,17 @@ bejson.com##div[id^="mylinks"]
 ||bejson.com/static/3part/layer1/layer
 ||bingfeng.tw/data/attachment/common/cf/$rewrite=abp-resource:1x1-transparent-gif,domain=bingfeng.tw
 $script,subdocument,third-party,xmlhttprequest,domain=alicili.me|alicili8.com|alicilibt.com|bittorrentsearchweb.com|btdiggba.me|btdiggba.ws|btdiggcn.xyz|btdiggs.co|btkitty.com|btkitty.pet|btkittyba.cc|btkittyba.me|btkittyba.net|btkittyba.pw|btkittyla.me|btkittyla.org|btkittyon.co|btkittyplus.cc|btlibrary.xyz|btlibrarys.cc|btlibrarys.net|btspread.cc|cilidaquan.co|cilidaquan.top|cilidaquancn.pw|cilidb.net|cilifanhao.ws|cilifanhaobt.xyz|cnbtdigg.pw|cnbtkitty.xyz|cncilidb.pw|cntorrentkitty.co|cnzhongzicili.net|diggbts.cc|diggbts.xyz|feifeibt.pw|godiggbt.org|godiggbts.cc|kikibt.me|kikibts.org|mybtlibrary.cc|nanrenbt.cc|newbtkitty.me|newbtkitty.pw|newbtspread.ws|okbtkitty.me|renrencili.pw|renrencili.xyz|savebt.pw|sousoucili.com|storebt.net|storetorrents.com|torrentkitty.app|torrentsearchweb.xyz|zhainanbt.me|zhongzicilibt.org|zhongzicilicn.com|zhongzicilicn.ws|zhongzicilicn.xyz|zhongzicilila.cc|zhongzicilila.co|zhongziciliso.net|zhongzifuli.cc|zhongzishenqi.ws
-@@||jsdelivr.net/opensug/1.1.2/opensug.js
 btzhongzifuli.com,cililianbt.org,maomaobt.cc,sousoucili.com,zhainanzhongzi.cc##.photos
 ||0377shujuhuifu.top^
-||1711811.com^
 ||60608787.com^
 ||711983.com^
 ||fjmailia.com^
 ||front99.com^
 ||jjqyk.com^
 ||miaobeichina.com^
-||mightiger.net^
 ||caoimg.xyz/images/
-china.cn##.ltp_box
-||techroomage.com^$csp=script-src 'self' * 'unsafe-eval'
 @@||8ox.cn/pge/?s=$script,domain=dlkoo.com
 @@||dlkoo.com/down/Copydown1
-||yi71.com.cn^
 ||ifun.tv/a/$xmlhttprequest
 ||s1-a4.ifun.tv^$rewrite=abp-resource:blank-mp3,domain=ifun.tv
 fuliba.net,uliba.net##.widget_custom_html:nth-child(2)
@@ -10270,19 +9854,14 @@ ifeng.com,~imall.ifeng.com##a[href*="imall.ifeng."]
 ||cryptaloot.pro^
 ||com/js/ddd.js
 ||com/js/indextop.js
-/1*.html?|$script,third-party,xmlhttprequest
-/1*.xhtml?|$script,third-party,xmlhttprequest
-/2*.html?|$script,third-party,xmlhttprequest
-/3*.html?|$script,third-party,xmlhttprequest
-_1xhtml?$script,third-party
 @@/ad.aspx|$domain=biqudao.com|ldzw.com|xdingdiann.com
 @@||bdimg.com/libs/$domain=00ksw.com|147xiaoshuo.com|18xs.org|1biquge.com|23us.la|23xsw.cc|52biquge.com|b5200.net|biqiuge.com|biqiugexsw.com|biquge.lu|biquge.tv|biquge.tw|biquge5200.cc|biquge9.cc|biqugecd.com|biqugeg.com|biquger.com|biqugetv.com|biqugex.com|biquguan.com|biqukan.com|biqumo.com|biquw.com|bixia.org|boquge.com|bqg5.cc|bqg99.cc|ddbiquge.cc|didaxiaoshuo.cc|gdbzkz.com|gzbpi.com|huanyue123.com|iqksw.com|janpn.com|jx.la|ldks.cc|lindiankanshu.cc|m.sjtxt.la|malshenzu.com|maopuzw.com|meegoq.com|paoshu8.com|qianrenge.cc|shuquge.com|touxiang.la|ttzw.tv|txtwan.com|uu234.cc|x23us.me|xbiqugecc.com|xinxs.la|xshengyan.com|xshuyaya.com|xsw55.com|xwxguan.com|xxqb5200.com|xyangguiweihuo.com|ymxxs.com|yssm.tv|yuyouge.com|zanghaihuatxt.com|zbzw.la|ztv.la
 @@||bdstatic.com/static/v1/mip$domain=biqugecom.com
 @@||bdstatic.com^$domain=17k.com|bxwx666.org
 @@||c.mipcdn.com^$domain=77dushu.com|biqugecom.com|prpcoin.com|zhetian.org
-@@||cdn.bootcss.com^$script,domain=59xs.com|biqudd.com|didaxiaoshuo.cc|geilwx.com|shudai.org|xhxswz.com|xsw55.com|ysxs8.com
+@@||cdn.bootcss.com^$script,domain=59xs.com|biqudd.com|didaxiaoshuo.cc|rijutv.com|shudai.org|xhxswz.com|xsw55.com|ysxs8.com
 @@||cdn.jsdelivr.net^$script,domain=35xss.com
-@@||cdn.staticfile.org^$script,domain=00ksw.com|147xiaoshuo.com|31xs.org|31xsxs.com|35xs.org|49zw.com|biquge18.com|biququ.info|qihaoqihao.com|tsxsw.net|xbiqugexsw.com|xx31xs.org|ziyouge.com
+@@||cdn.staticfile.org^$script,domain=00ksw.com|147xiaoshuo.com|31xs.org|31xsxs.com|35xs.org|biquge18.com|biququ.info|manhuadui.com|qihaoqihao.com|rijutv.com|tsxsw.net|xbiqugexsw.com|xx31xs.org|ziyouge.com
 ##a[href^="https://uds24.com/"]
 ||com/code.php?a=index&z=$script,third-party,xmlhttprequest
 ||m.23txt.com^
@@ -10298,23 +9877,17 @@ _1xhtml?$script,third-party
 ||m.lanseshuba.com^
 ||m.muyuge.com^
 ||m.x81zw.com^
-||m.xiaoshuodaquan.com^
-||m.yuyouge.com^
 ||m.zineworm.com^
 ||m.zwda.com^
 ||m.zwdu.com^
 ||wap.x4399.com^
 ||wap.yb3.cc^
-@@||dzz8.com/public/ptcms/*.js?g=$domain=m.daizhuzai.com
-@@||meiwenfen.com^$xmlhttprequest,domain=520tingshu.com
 ||0577renliu.
 ||0n6h.cn^
 ||12381236.com^
 ||17zheng.cn^
 ||1r49n.cn^
 ||1x26q3.cn^
-||23txt.com^$third-party
-||30sy.com/ucweb/
 ||365yigou.cn^
 ||51posuiji.org.cn^
 ||555b2b.com^
@@ -10328,7 +9901,6 @@ _1xhtml?$script,third-party
 ||abfirst.cn^
 ||actingidekex.cn^
 ||aganj.com^
-||aikanshu8.com/novel/js/hm
 ||aiode.cn^
 ||amu520.com/imgnk/02.gif
 ||ayues.com^
@@ -10356,7 +9928,6 @@ _1xhtml?$script,third-party
 ||epanr.com^
 ||feifish66.com^
 ||feizw.com/style/t.js
-||fwyang.com^
 ||guxiaom.cn^
 ||hbfie.org/mh
 ||hellogalaxy.cn^
@@ -10386,7 +9957,6 @@ _1xhtml?$script,third-party
 ||okuis.com^
 ||once88.cn^
 ||oomyv.com^
-||ow*.biqugego.com^
 ||picbr.com^
 ||piliangzhuce.cn^
 ||pptte.com^
@@ -10394,11 +9964,9 @@ _1xhtml?$script,third-party
 ||qlaot.com^
 ||qqiat.com^
 ||quldu.com^
-||qyttl.cn^
 ||sdaiv.com^
 ||self-study-service.com.cn^
 ||siguatv.cn^
-||slivercommander.cn^
 ||slvtx.com^
 ||suolaka.23txt.com^
 ||sxjkc.cn^
@@ -10420,7 +9988,6 @@ _1xhtml?$script,third-party
 ||wonwg.com^
 ||wsxxu.com^
 ||wxmg2016.com^
-||x81zw.com^*.gif
 ||xiakelea.com^
 ||xinterface.cn^
 ||xnghmc.com^
@@ -10431,11 +9998,7 @@ _1xhtml?$script,third-party
 ||yueyelive.com^
 ||yuxyz.com^
 ||zx-jsp.com^
-@@||meizitu.net/mfiles/m.js$domain=m.mzitu.com
-|https:$script,third-party,xmlhttprequest,domain=m.733.so|m.mzitu.com|m.umei.cc
 ||*^sdtfrom=^$rewrite=abp-resource:blank-mp3,domain=qq.com
-rjno1.com##div[style="display:none"]
-||rjno1.com^$csp=script-src 'self' *;style-src
 173.192.147.21,iu91.co,ozxw.co,sejie.com,sejie2.us,sejie3.us,thesoccerline.com,ukhuaren.co###wp > br
 ||www.wifi588.net^*.gif
 baike567.com,wuhaozhan.net##.pure-u-md-8-24 iframe
@@ -10452,26 +10015,11 @@ thzx.cc##style + div[style="margin-bottom:5px"]
 ||212.64.34.17^
 ||45.126.123.80^
 ||withad.cn^
-dota2.com.cn#@##bdshare
-sogou.com#@##shareContent
 zdzdm.com#@##share_list
-harrynull.tech#@##sharelist
-zhihu.com#@#.FollowButton
-zhihu.com#@#.LikeButton
 cokemine.com,eveaz.com,jubuzz.com,tianfateng.cn#@#.category-share
-bilibili.com#@#.follow-wrapper
-gamersky.com#@#.like2
-music.163.com#@#.p-share
-zhidao.baidu.com#@#.share-area
 baidu.com,youdao.com#@#.share-content
-youdao.com#@#.share-icon
-kuaishou.com#@#.share-page
-zhidao.baidu.com#@#.share-section
-baidusu.com#@#.share-wrapper
 5dm.tv#@#.tm-share-this
-@@||bdstatic.com^*/share_
 @@||jsdelivr.net/combine/npm/jquery@3,npm/social-share.js
-@@||yimg.com^*/react-share-buttons.
 @@/fingerprint2.js$domain=fangcloud.com|fx678.com|pop-fashion.com
 @@/iplookup.$domain=cankaoxiaoxi.com|dilidili.wang|dongfeng-nissan.com.cn|huomao.com|loldk.com|sina.com.cn
 @@=mm_12852562_1778064_$domain=alimarket.tmall.com|www.taobao.com|www.tmall.com
@@ -10483,7 +10031,6 @@ baidusu.com#@#.share-wrapper
 @@||viu.com/ott/*/js/tracking/
 ||h-adashx.ut.taobao.com^
 ||ug.snssdk.com^
-$image,domain=ip.cn
 ||x.jd.com^
 ||agstat.html5.qq.com^
 ||growthpic.weishi.qq.com^
@@ -10572,8 +10119,6 @@ baidu.com###page-copyright
 ||sdk.api.oaid.wocloud.cn^
 ||yhg28.xyz/templates/btbook/js/default.js
 ||yhg28.xyz/js/tongji.js
-QURna+inhOWImQ==
-||vtqifk86868.cn^
 ||znlgplt.com^
 /AdBanner
 ||tdum.alibaba.com/dss.js
@@ -10589,7 +10134,6 @@ QURna+inhOWImQ==
 ||dns.ximalaya.com^
 ||adse.wsa.ximalaya.com^
 ||adsebs.ximalaya.com^
-||oiwjcsh012.top^
 ||lishibu.com^
 ||app.market.xiaomi.com/apm/recommend/downloadmanagerV2?
 ||app.market.xiaomi.com/apm/recommend/upgradepage?
@@ -10612,12 +10156,10 @@ ruanyifeng.com$$script[tag-content="background"]
 ||156.247.120.15^
 ||156.247.120.31^
 ||hiqidi.com^
-/\/1xhtml\?\d+/$third-party
 ||izuiyou.com/ad^
 manhuatai.com$$div[class="acgn-dynamic-content"]
 /getadvertise^
 ||app.bilibili.com/x/v2/account/mine?$replace=/\{\"id\"\:424.*?\}//
-_1xhtml?|
 /\(com\?\d+/$third-party
 ||cm.bilibili.com/admonitor^
 ||m.yse1234.com/template/phone/imagess/sdfwef.js


### PR DESCRIPTION
手动同步了easylischina近几个月[移除的规则](https://github.com/easylist/easylistchina/search?q=removed+obsolete+filters&type=commits) (从 b444fcd96c73764b7b0c2f22d201094c97d51bb5 到 17be3f69bb933fda4fffbfdcbb1b69de6f3e1ca1)。通过比较ADgk与[b444f版本的easylistchina](https://raw.githubusercontent.com/easylist/easylistchina/b444fcd96c73764b7b0c2f22d201094c97d51bb5/easylistchina.txt)，移除了ADgk中与easylistchina重复的规则。顺手修改了其他几条规则。