### PR TITLE
GitHub Linguist support for adblock filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable

--- a/ADgk.txt
+++ b/ADgk.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0]
 ! Version: 20220902085332
 ! Title: adgk手机去广告规则
 ! Homepage: https://github.com/banbendalao/ADgk

--- a/kill-baidu-ad.txt
+++ b/kill-baidu-ad.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0]
 ! Title: 百度搜索结果极限净化
 ! Description: 效果过于强大，慎用
 ! Last Modified: 2019/1/29


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401