### PR TITLE
规则误杀太严重了

### DIFF
--- a/ADgk.txt
+++ b/ADgk.txt
@@ -5285,8 +5285,6 @@ play.baidu.com###m-client-product,#right-ads,div.rightAd-skin,.top-banner-ad-wra
 ||img.baidu.com/hunter/musicmonkey.min.js
 ||hiphotos.baidu.com/ting/pic/item/
 ||music.baidu.com/data/69xiu/
-||ad.
-*/ad.
 */adbox/
 */ads.
 */adload.


### PR DESCRIPTION
||ad. 这个规则误杀太严重了, Quark 的一大堆业务域名全被误杀了 

![image](https://user-images.githubusercontent.com/67973160/217921634-b579003b-5169-4d1c-b09f-6a0c013201b7.png)

![image](https://user-images.githubusercontent.com/67973160/217921727-398f8dce-9a3d-48eb-bb0d-6619b6fdc41d.png)
